### PR TITLE
Add VictoriaMetrics for local dev + initialize scraping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build:
 .PHONY: build_and_watch
 ## Continous build Pocket's main entrypoint as files change
 build_and_watch:
-	/bin/sh ${PWD}/scripts/watch_build.sh
+	/bin/sh ${PWD}/build/scripts/watch_build.sh
 
 .PHONY: client_start
 ## Run a client daemon which is only used for debugging purposes

--- a/build/deployments/docker-compose.yaml
+++ b/build/deployments/docker-compose.yaml
@@ -141,6 +141,23 @@ services:
     ports:
       - "5050:5050"
 
+  vm:
+    container_name: victoria-metrics
+    image: victoriametrics/victoria-metrics
+    restart: always
+    ports:
+      - "8428:8428"
+    volumes:
+      - vm:/storage
+      - ./victoria-metrics:/configs
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - "--storageDataPath=/storage"
+      - "--httpListenAddr=:8428"
+      - "--promscrape.config=/configs/scrape.yml"
+
 volumes:
   db:
+    driver: local
+  vm:
     driver: local

--- a/build/deployments/victoria-metrics/scrape.yml
+++ b/build/deployments/victoria-metrics/scrape.yml
@@ -7,13 +7,24 @@ scrape_configs:
   - job_name: "victoria-metrics"
     static_configs:
       - targets: ["localhost:8428"]
-  - job_name: "docker-containers"
+  - job_name: "pocket-nodes"
     docker_sd_configs:
       - host: unix:///var/run/docker.sock # You can also use http/https to connect to the Docker daemon.
-        port: 9000
     relabel_configs:
-      # directory where docker-compose.yml file resides called `deployments` so we can configure SD to only pick up containers related to this docker-compose.
+      # only keep node\d.consensus containers in the discovery.
       - source_labels:
           [__meta_docker_container_label_com_docker_compose_project]
         regex: deployments
         action: keep
+      - source_labels: [__meta_docker_container_name]
+        regex: /node\d?.consensus
+        action: keep
+      - source_labels: ["__address__"]
+        separator: ":"
+        regex: '(.*):(\d*)'
+        target_label: "__address__"
+        replacement: "${1}:9000"
+      - source_labels:
+          [__meta_docker_container_label_com_docker_compose_service]
+        target_label: instance
+        replacement: "${1}"

--- a/build/deployments/victoria-metrics/scrape.yml
+++ b/build/deployments/victoria-metrics/scrape.yml
@@ -1,0 +1,19 @@
+# You can follow prometheus config syntax here.
+
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "victoria-metrics"
+    static_configs:
+      - targets: ["localhost:8428"]
+  - job_name: "docker-containers"
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock # You can also use http/https to connect to the Docker daemon.
+        port: 9000
+    relabel_configs:
+      # directory where docker-compose.yml file resides called `deployments` so we can configure SD to only pick up containers related to this docker-compose.
+      - source_labels:
+          [__meta_docker_container_label_com_docker_compose_project]
+        regex: deployments
+        action: keep

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -19,6 +19,7 @@ Please note that this repository is under very active development and breaking c
 - Install [Docker Compose](https://docs.docker.com/compose/install/)
 - Install [Golang](https://go.dev/doc/install)
 - Install [protoc-gen-go](https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go)
+- Install [mockgen](https://github.com/golang/mock#installation=)
 
 ### Prepare Local Environment
 
@@ -27,8 +28,8 @@ Generate local files
 ```bash
 $ make protogen_clean
 $ make protogen_local
-$ go mod vendor && go mod tidy
 $ make mockgen
+$ go mod vendor && go mod tidy
 ```
 
 ### View Available Commands


### PR DESCRIPTION
Adding victoria metrics container, plus service discovery configuration that assumes the exporter is going to be running on `:9000/metrics`.

Also some little tweaks in docs/Makefile due to issues I ran into during onboarding.