### PR TITLE
fix make protogen_docker old command to help resolve protogen issues on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ protogen_docker_m1: docker_check
 .PHONY: protogen_docker
 ## TODO(derrandz): Test, validate & update.
 protogen_docker: docker_check
-	docker build -t pocket/proto-generator -f ./build/Dockerfile.proto . && docker run -it pocket/proto-generator
+	docker build -t pocket/proto-generator -f ./build/Dockerfile.proto . && docker run -it -v $(CWD)/:/usr/src/app/ pocket/proto-generator
 
 .PHONY: gofmt
 ## Format all the .go files in the project in place.

--- a/build/Dockerfile.proto
+++ b/build/Dockerfile.proto
@@ -1,7 +1,7 @@
 FROM golang:latest
 
 # Install grpc
-RUN go get -u github.com/golang/protobuf/protoc-gen-go
+RUN go install github.com/golang/protobuf/protoc-gen-go@latest
 
 
 # update
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get install -y zip && \
 
 ENV PATH=$PATH:$GOPATH/bin:/opt/protoc/bin
 
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+
 COPY . .
 
-RUN make protogen_local && echo "Done."
+CMD make protogen_local && make protogen_show && echo "Done." && exit 0


### PR DESCRIPTION
## Description
Updates the Dockerfile and the commands to make `make protogen_docker` functional.


## Type of change
Please mark the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Local infrastructure tooling

## How Has This Been Tested?

By running:

Destroy your existing protobuff generated files by running:
```bash
$ make protogen_clean
```

Then run:
```bash
$ CWD=$(pwd) make protogen_docker
```

Then check if protobuff files are generated under their respective directories (_check `shared/types/` for instance_)

## Owners

@derrandz 