### PR TITLE
[Stale] [Telemetry] Introduce a singleton std logger to the codebase to unify logs

### DIFF
--- a/consensus/leader_election/module.go
+++ b/consensus/leader_election/module.go
@@ -5,6 +5,7 @@ import (
 
 	typesCons "github.com/pokt-network/pocket/consensus/types"
 	"github.com/pokt-network/pocket/shared/config"
+	"github.com/pokt-network/pocket/shared/logging"
 	"github.com/pokt-network/pocket/shared/modules"
 )
 
@@ -43,6 +44,10 @@ func (m *leaderElectionModule) GetBus() modules.Bus {
 		log.Fatalf("PocketBus is not initialized")
 	}
 	return m.bus
+}
+
+func (m *leaderElectionModule) Logger() logging.Logger {
+	return m.GetBus().GetTelemetryModule().Logger()
 }
 
 func (m *leaderElectionModule) ElectNextLeader(message *typesCons.HotstuffMessage) (typesCons.NodeId, error) {

--- a/consensus/module.go
+++ b/consensus/module.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/pokt-network/pocket/shared/logging"
 	"github.com/pokt-network/pocket/shared/types"
 
 	"github.com/pokt-network/pocket/consensus/leader_election"
@@ -151,6 +152,10 @@ func (m *consensusModule) SetBus(pocketBus modules.Bus) {
 	m.bus = pocketBus
 	m.paceMaker.SetBus(pocketBus)
 	m.leaderElectionMod.SetBus(pocketBus)
+}
+
+func (m *consensusModule) Logger() logging.Logger {
+	return m.GetBus().GetTelemetryModule().Logger()
 }
 
 func (m *consensusModule) loadPersistedState() error {

--- a/consensus/pacemaker.go
+++ b/consensus/pacemaker.go
@@ -8,6 +8,7 @@ import (
 	consensusTelemetry "github.com/pokt-network/pocket/consensus/telemetry"
 	typesCons "github.com/pokt-network/pocket/consensus/types"
 	"github.com/pokt-network/pocket/shared/config"
+	"github.com/pokt-network/pocket/shared/logging"
 
 	"github.com/pokt-network/pocket/shared/modules"
 )
@@ -81,6 +82,10 @@ func (m *paceMaker) GetBus() modules.Bus {
 		log.Fatalf("PocketBus is not initialized")
 	}
 	return m.bus
+}
+
+func (m *paceMaker) Logger() logging.Logger {
+	return m.GetBus().GetTelemetryModule().Logger()
 }
 
 func (m *paceMaker) SetConsensusModule(c *consensusModule) {

--- a/persistence/module.go
+++ b/persistence/module.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/pokt-network/pocket/persistence/kvstore"
 	"github.com/pokt-network/pocket/shared/config"
+	"github.com/pokt-network/pocket/shared/logging"
 	"github.com/pokt-network/pocket/shared/modules"
 
 	"github.com/syndtr/goleveldb/leveldb/memdb"
@@ -115,6 +116,10 @@ func (m *persistenceModule) GetBus() modules.Bus {
 		log.Fatalf("PocketBus is not initialized")
 	}
 	return m.bus
+}
+
+func (m *persistenceModule) Logger() logging.Logger {
+	return m.GetBus().GetTelemetryModule().Logger()
 }
 
 func (m *persistenceModule) NewContext(height int64) (modules.PersistenceContext, error) {

--- a/persistence/pre_persistence/module.go
+++ b/persistence/pre_persistence/module.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/pokt-network/pocket/shared/logging"
 	typesGenesis "github.com/pokt-network/pocket/shared/types/genesis"
 
 	"github.com/pokt-network/pocket/shared/config"
@@ -50,6 +51,10 @@ func (m *PrePersistenceModule) GetBus() modules.Bus {
 		log.Fatalf("PocketBus is not initialized")
 	}
 	return m.bus
+}
+
+func (m *PrePersistenceModule) Logger() logging.Logger {
+	return m.GetBus().GetTelemetryModule().Logger()
 }
 
 func InitGenesis(u *PrePersistenceContext, genesisState *typesGenesis.GenesisState) error {

--- a/shared/logging/loggers.go
+++ b/shared/logging/loggers.go
@@ -13,3 +13,27 @@ func GetGlobalLogger() Logger {
 	}
 	return singletonLogger
 }
+
+func Info(args ...any) {
+	GetGlobalLogger().Info(args...)
+}
+
+func Error(args ...any) {
+	GetGlobalLogger().Error(args...)
+}
+
+func Warn(args ...any) {
+	GetGlobalLogger().Warn(args...)
+}
+
+func Debug(args ...any) {
+	GetGlobalLogger().Debug(args...)
+}
+
+func Fatal(args ...any) {
+	GetGlobalLogger().Fatal(args...)
+}
+
+func Log(args ...any) {
+	GetGlobalLogger().Log(args...)
+}

--- a/shared/logging/loggers.go
+++ b/shared/logging/loggers.go
@@ -1,9 +1,15 @@
 package logging
 
-var (
-	singletonLogger = CreateStdLogger(LOG_LEVEL_ALL)
-)
+import "sync"
+
+var singletonLogger Logger
+var singletonLock = &sync.Mutex{}
 
 func GetGlobalLogger() Logger {
+	if singletonLogger == nil {
+		singletonLock.Lock()
+		defer singletonLock.Unlock()
+		singletonLogger = CreateStdLogger(LOG_LEVEL_ALL, GLOBAL_NAMESPACE, POCKET_LOGS_PREFIX)
+	}
 	return singletonLogger
 }

--- a/shared/logging/loggers.go
+++ b/shared/logging/loggers.go
@@ -1,0 +1,9 @@
+package logging
+
+var (
+	singletonLogger = CreateStdLogger(LOG_LEVEL_ALL)
+)
+
+func GetGlobalLogger() Logger {
+	return singletonLogger
+}

--- a/shared/logging/std_logger.go
+++ b/shared/logging/std_logger.go
@@ -1,0 +1,82 @@
+package logging
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+)
+
+type stdLogger struct {
+	*log.Logger
+	*sync.Mutex
+	namespace Namespace
+	level     LogLevel
+}
+
+func CreateStdLogger(level LogLevel) Logger {
+	return &stdLogger{
+		Mutex:     &sync.Mutex{},
+		Logger:    log.New(os.Stdout, "[pocket]", 0),
+		level:     LOG_LEVEL_ALL,
+		namespace: GLOBAL_NAMESPACE,
+	}, nil
+}
+
+func (sla *stdLogger) decorate(decor string, args []any) []any {
+	fArgs := []any{decor}
+	fArgs = append(fArgs, args...)
+	return fArgs
+}
+
+func (sla *stdLogger) logIfAtLevel(level LogLevel, args ...any) {
+	if sla.level != LOG_LEVEL_NONE && (sla.level == level || sla.level == LOG_LEVEL_ALL) {
+		defer sla.Unlock()
+		sla.Lock()
+
+		namespacedArgs := []any{
+			sla.namespace,
+		}
+		namespacedArgs = append(namespacedArgs, args...)
+		logLine := sla.decorate(fmt.Sprintf("[%s]:", level), namespacedArgs)
+
+		if sla.level == LOG_LEVEL_FATAL {
+			sla.Logger.Fatal(logLine...)
+		} else {
+			sla.Logger.Println(logLine...)
+		}
+	}
+}
+
+// Interface for logging
+func (sla *stdLogger) Info(args ...any) {
+	sla.logIfAtLevel(LOG_LEVEL_INFO, args...)
+}
+
+func (sla *stdLogger) Error(args ...any) {
+	sla.logIfAtLevel(LOG_LEVEL_ERROR, args...)
+}
+
+func (sla *stdLogger) Warn(args ...any) {
+	sla.logIfAtLevel(LOG_LEVEL_WARN, args...)
+}
+
+func (sla *stdLogger) Debug(args ...any) {
+	sla.logIfAtLevel(LOG_LEVEL_DEBUG, args...)
+}
+
+func (sla *stdLogger) Fatal(args ...any) {
+	sla.logIfAtLevel(LOG_LEVEL_FATAL, args...)
+}
+
+func (sla *stdLogger) Log(args ...any) {
+	sla.logIfAtLevel(LOG_LEVEL_ALL, args...)
+}
+
+func (sla *stdLogger) SetLevel(l LogLevel) {
+	sla.level = l
+}
+
+func (sla *stdLogger) SetNamespace(namespace Namespace) {
+	sla.namespace = namespace
+}

--- a/shared/logging/std_logger_test.go
+++ b/shared/logging/std_logger_test.go
@@ -1,0 +1,205 @@
+package telemetry
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/pokt-network/pocket/shared/modules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStdLogAgent_New(t *testing.T) {
+	logger := NewLogger(
+		modules.LOG_LEVEL_ALL,
+		bufio.NewWriter(
+			bytes.NewBuffer([]byte{}),
+		),
+	)
+
+	assert.NotNil(
+		t,
+		logger,
+		"logger: could not instantiate logger",
+	)
+
+	assert.NotNil(
+		t,
+		logger.SetOutput,
+		"logger: could not retrieve the logger ref",
+	)
+}
+
+func TestStdLogAgent_Debug(t *testing.T) {
+	var logger *StdLogAgent
+	var namespace string = "telemetry"
+	var sentence string = "logging lorem ipsum"
+	var level string = "[DEBUG]"
+	var prefix string = "[pocket]"
+
+	// initialization
+	{
+		logger = NewLogger(
+			modules.LOG_LEVEL_DEBUG,
+			bufio.NewWriter(
+				bytes.NewBuffer([]byte{}),
+			),
+		)
+
+		assert.NotNil(
+			t,
+			logger.Debug,
+			"logger: Debug() is nil, check if it's implemented",
+		)
+	}
+
+	// Debug print correction assertion
+	{
+		b := make([]byte, 0)
+		buffer := bytes.NewBuffer(b)
+		writer := bufio.NewWriter(buffer)
+
+		logger = NewLogger(modules.LOG_LEVEL_DEBUG, writer)
+
+		logger.Debug(namespace, sentence)
+
+		writer.Flush()
+
+		assert.Equal(
+			t,
+			fmt.Sprintf("%s%s: %s %s\n", prefix, level, namespace, sentence),
+			string(buffer.Bytes()),
+		)
+	}
+
+}
+
+func TestStdLogAgent_Log(t *testing.T) {
+	var logger *StdLogAgent
+	var namespace string = "p2p"
+	var sentence string = "logging lorem ipsum"
+	var level string = "[LOG]"
+	var prefix string = "[pocket]"
+
+	// initialization
+	{
+		logger = NewLogger(
+			modules.LOG_LEVEL_ALL,
+			bufio.NewWriter(
+				bytes.NewBuffer([]byte{}),
+			),
+		)
+
+		assert.NotNil(
+			t,
+			logger.Log,
+			"logger: Log() is nil, check if it's implemented",
+		)
+	}
+
+	// Debug print correction assertion
+	{
+		b := make([]byte, 0)
+		buffer := bytes.NewBuffer(b)
+		writer := bufio.NewWriter(buffer)
+
+		logger = NewLogger(modules.LOG_LEVEL_ALL, writer)
+
+		logger.Log(namespace, sentence)
+
+		writer.Flush()
+
+		assert.Equal(
+			t,
+			fmt.Sprintf("%s%s: %s %s\n", prefix, level, namespace, sentence),
+			string(buffer.Bytes()),
+		)
+	}
+}
+
+func TestStdLogAgent_Info(t *testing.T) {
+	var logger *StdLogAgent
+	var namespace = "utils"
+	var sentence string = "logging lorem ipsum"
+	var level string = "[INFO]"
+	var prefix string = "[pocket]"
+
+	// initialization
+	{
+		logger = NewLogger(
+			modules.LOG_LEVEL_INFO,
+			bufio.NewWriter(
+				bytes.NewBuffer([]byte{}),
+			),
+		)
+
+		assert.NotNil(
+			t,
+			logger.Info,
+			"logger: INFO() is nil, check if it's implemented",
+		)
+	}
+
+	// Debug print correction assertion
+	{
+		b := make([]byte, 0)
+		buffer := bytes.NewBuffer(b)
+		writer := bufio.NewWriter(buffer)
+
+		logger = NewLogger(modules.LOG_LEVEL_INFO, writer)
+
+		logger.Info(namespace, sentence)
+
+		writer.Flush()
+
+		assert.Equal(
+			t,
+			fmt.Sprintf("%s%s: %s %s\n", prefix, level, namespace, sentence),
+			string(buffer.Bytes()),
+		)
+	}
+}
+
+func TestStdLogAgent_Error(t *testing.T) {
+	var logger *StdLogAgent
+	var namespace string = "consensus"
+	var sentence string = "logging lorem ipsum"
+	var level string = "[ERROR]"
+	var prefix string = "[pocket]"
+
+	// initialization
+	{
+		logger = NewLogger(
+			modules.LOG_LEVEL_ERROR,
+			bufio.NewWriter(
+				bytes.NewBuffer([]byte{}),
+			),
+		)
+
+		assert.NotNil(
+			t,
+			logger.Error,
+			"logger: Error() is nil, check if it's implemented",
+		)
+	}
+
+	// Debug print correction assertion
+	{
+		b := make([]byte, 0)
+		buffer := bytes.NewBuffer(b)
+		writer := bufio.NewWriter(buffer)
+
+		logger = NewLogger(modules.LOG_LEVEL_ERROR, writer)
+
+		logger.Error(namespace, sentence)
+
+		writer.Flush()
+
+		assert.Equal(
+			t,
+			fmt.Sprintf("%s%s: %s %s\n", prefix, level, namespace, sentence),
+			string(buffer.Bytes()),
+		)
+	}
+}

--- a/shared/logging/types.go
+++ b/shared/logging/types.go
@@ -1,0 +1,59 @@
+package logging
+
+import "strings"
+
+type LogLevel string
+
+const (
+	LOG_LEVEL_NONE  LogLevel = "NONE"
+	LOG_LEVEL_INFO           = "INFO"
+	LOG_LEVEL_ERROR          = "ERROR"
+	LOG_LEVEL_DEBUG          = "DEBUG"
+	LOG_LEVEL_WARN           = "WARN"
+	LOG_LEVEL_FATAL          = "FATAL"
+	LOG_LEVEL_ALL            = "LOG"
+)
+
+type Namespace string
+
+const (
+	CONSENSUS_NAMESPACE   Namespace = "CONSENSUS"
+	P2P_NAMESPACE                   = "P2P"
+	UTILITY_NAMESPACE               = "UTILITY"
+	PERSISTENCE_NAMESPACE           = "PERSISTENCE"
+	GLOBAL_NAMESPACE                = "GLOBAL"
+)
+
+// Interface for logging
+type Logger interface {
+	SetLevel(LogLevel)
+	SetNamespace(Namespace)
+
+	Info(args ...any)  // level = info
+	Error(args ...any) // level = error
+	Warn(args ...any)  // level = warn
+	Debug(args ...any) // level = debug
+	Fatal(args ...any) // level = fatal
+	Log(args ...any)   // level = all
+}
+
+type LoggerConfig map[Namespace]LogLevel
+
+func GetLevel(level string) LogLevel {
+	switch level {
+	case strings.ToLower(string(LOG_LEVEL_ALL)):
+		return LOG_LEVEL_ALL
+	case strings.ToLower(string(LOG_LEVEL_FATAL)):
+		return LOG_LEVEL_FATAL
+	case strings.ToLower(string(LOG_LEVEL_ERROR)):
+		return LOG_LEVEL_ERROR
+	case strings.ToLower(string(LOG_LEVEL_DEBUG)):
+		return LOG_LEVEL_DEBUG
+	case strings.ToLower(string(LOG_LEVEL_WARN)):
+		return LOG_LEVEL_WARN
+	case strings.ToLower(string(LOG_LEVEL_INFO)):
+		return LOG_LEVEL_INFO
+	default:
+		return LOG_LEVEL_NONE
+	}
+}

--- a/shared/logging/types.go
+++ b/shared/logging/types.go
@@ -21,8 +21,10 @@ const (
 	P2P_NAMESPACE                   = "P2P"
 	UTILITY_NAMESPACE               = "UTILITY"
 	PERSISTENCE_NAMESPACE           = "PERSISTENCE"
-	GLOBAL_NAMESPACE                = "GLOBAL"
+	GLOBAL_NAMESPACE                = "SHARED"
 )
+
+var POCKET_LOGS_PREFIX = "POCKET"
 
 // Interface for logging
 type Logger interface {

--- a/shared/modules/module.go
+++ b/shared/modules/module.go
@@ -1,9 +1,13 @@
 package modules
 
+import "github.com/pokt-network/pocket/shared/logging"
+
 // TODO(olshansky): Show an example of `TypicalUsage`
 type Module interface {
 	IntegratableModule
 	InterruptableModule
+
+	Loggable
 }
 
 type IntegratableModule interface {
@@ -14,4 +18,8 @@ type IntegratableModule interface {
 type InterruptableModule interface {
 	Start() error
 	Stop() error
+}
+
+type Loggable interface {
+	Logger() logging.Logger
 }

--- a/shared/modules/telemetry_module.go
+++ b/shared/modules/telemetry_module.go
@@ -1,7 +1,6 @@
 package modules
 
 import (
-	"github.com/pokt-network/pocket/shared/logging"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -10,9 +9,6 @@ type TelemetryModule interface {
 
 	GetTimeSeriesAgent() TimeSeriesAgent
 	GetEventMetricsAgent() EventMetricsAgent
-
-	LoggerGet(namespace logging.Namespace) logging.Logger
-	LoggerRegister(namespace logging.Namespace, level logging.LogLevel) error
 }
 
 // Interface for the time series agent (prometheus)

--- a/shared/modules/telemetry_module.go
+++ b/shared/modules/telemetry_module.go
@@ -1,15 +1,19 @@
 package modules
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/pokt-network/pocket/shared/logging"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type TelemetryModule interface {
 	Module
 
 	GetTimeSeriesAgent() TimeSeriesAgent
 	GetEventMetricsAgent() EventMetricsAgent
-}
 
-// IMPROVE: Determine if the register function could (should?) return an error.
+	LoggerGet(namespace logging.Namespace) logging.Logger
+	LoggerRegister(namespace logging.Namespace, level logging.LogLevel) error
+}
 
 // Interface for the time series agent (prometheus)
 type TimeSeriesAgent interface {
@@ -19,7 +23,7 @@ type TimeSeriesAgent interface {
 	CounterRegister(name string, description string)
 
 	// Increments the counter
-	CounterIncrement(name string) // DISCUSS(team): Should this return an error if the counter does not exist?
+	CounterIncrement(name string)
 
 	/*** Gauges ***/
 
@@ -38,7 +42,7 @@ type TimeSeriesAgent interface {
 	// Adds the given value to the Gauge. A negative value results in a decrease of the Gauge.
 	GaugeAdd(name string, value float64) (prometheus.Gauge, error)
 
-	// Subtracts the given value from the Gauge. A negative value results in a increase of the Gauge.
+	// Subtracts the given value from the Gauge. (The value can be negative, resulting in an increase of the Gauge.)
 	GaugeSub(name string, value float64) (prometheus.Gauge, error)
 
 	/*** Gauge Vectors ***/
@@ -50,8 +54,7 @@ type TimeSeriesAgent interface {
 	GetGaugeVec(name string) (prometheus.GaugeVec, error)
 }
 
-// Interface for the event metrics agent
-// IMPROVE: This relies on logging at the moment and can be improved in the future
+// Interface for the event metrics agent (relies on logging ftm)
 type EventMetricsAgent interface {
 	EmitEvent(namespace, event_name string, labels ...any)
 }

--- a/shared/telemetry/noop_module.go
+++ b/shared/telemetry/noop_module.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/pokt-network/pocket/shared/config"
+	"github.com/pokt-network/pocket/shared/logging"
 	"github.com/pokt-network/pocket/shared/modules"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -103,4 +104,8 @@ func (p *NoopTelemetryModule) GetGaugeVec(name string) (prometheus.GaugeVec, err
 
 func (p *NoopTelemetryModule) GaugeVecRegister(namespace, module, name, description string, labels []string) {
 	NOOP()
+}
+
+func (p *NoopTelemetryModule) Logger() logging.Logger {
+	return logging.GetGlobalLogger()
 }

--- a/shared/telemetry/prometheus_module.go
+++ b/shared/telemetry/prometheus_module.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pokt-network/pocket/shared/config"
+	"github.com/pokt-network/pocket/shared/logging"
 	"github.com/pokt-network/pocket/shared/modules"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -198,4 +199,8 @@ func (p *PrometheusTelemetryModule) GetGaugeVec(name string) (prometheus.GaugeVe
 		return gv, NonExistentMetricErr("gauge vector", name, "get")
 	}
 	return prometheus.GaugeVec{}, nil
+}
+
+func (p *PrometheusTelemetryModule) Logger() logging.Logger {
+	return logging.GetGlobalLogger()
 }

--- a/utility/module.go
+++ b/utility/module.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/pokt-network/pocket/shared/config"
+	"github.com/pokt-network/pocket/shared/logging"
 	"github.com/pokt-network/pocket/shared/modules"
 	"github.com/pokt-network/pocket/shared/types"
 )
@@ -39,4 +40,8 @@ func (u *UtilityModule) GetBus() modules.Bus {
 		log.Fatalf("Bus is not initialized")
 	}
 	return u.bus
+}
+
+func (m *UtilityModule) Logger() logging.Logger {
+	return m.GetBus().GetTelemetryModule().Logger()
 }


### PR DESCRIPTION
## Description

In order to achieve the goals of logging for the [telemetry milestone](https://github.com/pokt-network/pocket/milestone/6), we will unify logging across the codebase by using a singleton logger. This logger will be imported directly in the shared scope of modules, but will also be used in the modules' scope through the telemetry module.

The origin document can be found here: https://github.com/pokt-network/pocket/issues/164

## Changes

- [ ] Introduced the `Logger` interface under `shared/logging`
- [ ] Implemented the `Logger` interface while using `log.Logger` as the log engine and `os.Stdout` as the output.
- [ ] Added support for multiple log levels and a method for each level with tests

The log line format is as follows:

```
YYYY/DD/MM HH:MM:SS | [PREFIX] [LEVEL] : [NAMESPACE] LOG_LINE....
```
Example:
```
2022/01/08 08:29:20 | [POCKET] [INFO] : [CONSENSUS] Successfully proposed a block
```

Please lookup the available levels and namespaces in `shared/logging/types.go`

## Owners

@derrandz 