### PR TITLE
Add make targets for config & genesis generation Issue #182

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ coverage.out
 
 # Output of `make build_and_watch`
 main
+
+# Ignored generated files by build/config/main.go
+build/config/gen*.json

--- a/Makefile
+++ b/Makefile
@@ -370,3 +370,8 @@ todo_count:
 ## List all the TODOs needed to be done in this commit
 todo_this_commit:
 	grep --exclude-dir={.git,vendor,prototype,.vscode} --exclude=Makefile -r -e "TODO_IN_THIS_COMMIT" -e "DISCUSS_IN_THIS_COMMIT"
+
+.PHONY: genesis_and_config
+## Generate the genesis and config files
+genesis_and_config:
+	go run ./build/config/main.go --numValidators="$(numValidators)" --numServiceNodes="$(numServiceNodes)" --numApplications="$(numApplications)" --numFishermen="$(numFishermen)"

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,19 @@ todo_count:
 todo_this_commit:
 	grep --exclude-dir={.git,vendor,prototype,.vscode} --exclude=Makefile -r -e "TODO_IN_THIS_COMMIT" -e "DISCUSS_IN_THIS_COMMIT"
 
-.PHONY: genesis_and_config
-## Generate the genesis and config files
-genesis_and_config:
+numValidators ?= 4
+numServiceNodes ?= 1
+numApplications ?= 1
+numFishermen ?= 1
+
+.PHONY: gen_genesis_and_config
+## Generate the genesis and config files for LocalNet
+gen_genesis_and_config:
 	go run ./build/config/main.go --numValidators="$(numValidators)" --numServiceNodes="$(numServiceNodes)" --numApplications="$(numApplications)" --numFishermen="$(numFishermen)"
+
+.PHONY: gen_genesis_and_config
+## Clear the genesis and config files for LocalNet
+clear_genesis_and_config:
+	rm build/config/gen.*.json
+
+rm build/config/gen.*.json

--- a/Makefile
+++ b/Makefile
@@ -379,11 +379,9 @@ numFishermen ?= 1
 .PHONY: gen_genesis_and_config
 ## Generate the genesis and config files for LocalNet
 gen_genesis_and_config:
-	go run ./build/config/main.go --numValidators="$(numValidators)" --numServiceNodes="$(numServiceNodes)" --numApplications="$(numApplications)" --numFishermen="$(numFishermen)"
+	go run ./build/config/main.go --genPrefix="gen." --numValidators=${numValidators} --numServiceNodes=${numServiceNodes} --numApplications=${numApplications} --numFishermen=${numFishermen}
 
 .PHONY: gen_genesis_and_config
 ## Clear the genesis and config files for LocalNet
 clear_genesis_and_config:
 	rm build/config/gen.*.json
-
-rm build/config/gen.*.json

--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,7 @@ todo_count:
 todo_this_commit:
 	grep --exclude-dir={.git,vendor,prototype,.vscode} --exclude=Makefile -r -e "TODO_IN_THIS_COMMIT" -e "DISCUSS_IN_THIS_COMMIT"
 
+# Default values for gen_genesis_and_config
 numValidators ?= 4
 numServiceNodes ?= 1
 numApplications ?= 1

--- a/build/config/README.md
+++ b/build/config/README.md
@@ -34,11 +34,11 @@ make numValidators=5 numServiceNodes=1 gen_genesis_and_config
 
 ### Parameters
 
-- `numValidators` is a string flag that sets the number of validators that will be in the network, this affects the
-  contents of the genesis file as well as the number of config files
-- `numServiceNodes` is a string flag that set the number of service nodes that will be in the network's genesis file
-- `numApplications` is a string flag that set the number of applications that will be in the network's genesis file
-- `numFishermen` is a string flag that set the number of fishermen that will be in the network's genesis file
+- `numValidators` is an int flag that sets the number of validators that will be in the network; this affects the contents of the genesis file as well as the number of config files
+- `numServiceNodes` is an int flag that set the number of service nodes that will be in the network's genesis file
+- `numApplications` is an int flag that set the number of applications that will be in the network's genesis file
+- `numFishermen` is an int flag that set the number of fishermen that will be in the network's genesis file
+- `genPrefix` is a string flag that adds a prefix to the generated files; is an empty string by default
 
 ## **WIP NOTE**
 

--- a/build/config/README.md
+++ b/build/config/README.md
@@ -29,7 +29,7 @@ go run ./build/config/main.go --numFishermen=1
 ### Using Make Target
 
 ```bash
-make numValidators=5 numServiceNodes=1 genesis_and_config
+make numValidators=5 numServiceNodes=1 gen_genesis_and_config
 ```
 
 ### Parameters

--- a/build/config/README.md
+++ b/build/config/README.md
@@ -1,47 +1,49 @@
-## Genesis and Configuration Generator
+# Genesis and Configuration Generator
 
-The Genesis and Configuration generator creates V1 config and genesis files with coordinated key pairings for `localnet`
-and `devnet` usage.
+The Genesis and Configuration generator creates V1 config and genesis files with coordinated key pairings for `localnet` and `devnet` usage.
 
-The purpose of this utility is to enable efficient and accurate `auto-generation` of configuration/genesis files anytime
-the source structures change during V1 development.
+The purpose of this utility is to enable efficient and accurate `auto-generation` of configuration/genesis files anytime the source structures change during V1 development.
 
-### *Disclaimer*
+## _Disclaimer_
 
 Both the genesis and configuration contents and generation are living WIPs that are subject to rapid, breaking changes.
 
 It is not recommended at this time to build infrastructure components that rely on the generator until it is stable
 
-### Origin Document
+## Origin Document
 
-Currently, the Genesis and Configuration generator is necessary to create development `localnet` environments
-for implementing V1. A current example of this is the `make compose_and_watch` debug utility that generates a localnet
-in a `docker compose` - injecting these appropriate config.json and genesis.json files
+Currently, the Genesis and Configuration generator is necessary to create development `localnet` environments for iterating on V1. A current example (as of 09/2022) of this is the `make compose_and_watch` debug utility that generates a `localnet` using `docker-compose` by injecting the appropriate `config.json` and `genesis.json` files.
 
-### Usage
+## Usage
 
-From source at project root: `go run ./build/config/main.go --numFishermen=1`
+The output files are written to `./build/config/`.
 
-From makefile at project root: `make numValidators=5 numServiceNodes=1 genesis_and_config`
+### Using Source
 
-The files output to the `./build/config/` directory
+From the project's root:
 
-#### Parameters
+```bash
+go run ./build/config/main.go --numFishermen=1
+```
 
-`numValidators` is a string flag that sets the number of validators that will be in the network, this affects the
-contents of the genesis file as well as the number of config files
+### Using Make Target
 
-`numServiceNodes` is a string flag that set the number of service nodes that will be in the network's genesis file
+```bash
+make numValidators=5 numServiceNodes=1 genesis_and_config
+```
 
-`numApplications` is a string flag that set the number of applications that will be in the network's genesis file
+### Parameters
 
-`numFishermen` is a string flag that set the number of fishermen that will be in the network's genesis file
+- `numValidators` is a string flag that sets the number of validators that will be in the network, this affects the
+  contents of the genesis file as well as the number of config files
+- `numServiceNodes` is a string flag that set the number of service nodes that will be in the network's genesis file
+- `numApplications` is a string flag that set the number of applications that will be in the network's genesis file
+- `numFishermen` is a string flag that set the number of fishermen that will be in the network's genesis file
 
-### **NOTE**
+## **WIP NOTE**
 
-The config and genesis files located in the `./build/config/` directory are needed for `make compose_and_watch` 
-and `make client_start && make client_connect`. 
+The config and genesis files located in the `./build/config/` directory are needed for following the local development instructions in `docs/development/README.md`.
 
-These builds expect four (valdiator) config and a single genesis file.
+These builds currently expect four (validator) `config.json` file and a single `genesis.json` file.
 
-Take caution when overwriting / deleting the files with different configurations
+Until #186 is implemented, take caution when overwriting / deleting the files with different configurations.

--- a/build/config/README.md
+++ b/build/config/README.md
@@ -1,0 +1,47 @@
+## Genesis and Configuration Generator
+
+The Genesis and Configuration generator creates V1 config and genesis files with coordinated key pairings for `localnet`
+and `devnet` usage.
+
+The purpose of this utility is to enable efficient and accurate `auto-generation` of configuration/genesis files anytime
+the source structures change during V1 development.
+
+### *Disclaimer*
+
+Both the genesis and configuration contents and generation are living WIPs that are subject to rapid, breaking changes.
+
+It is not recommended at this time to build infrastructure components that rely on the generator until it is stable
+
+### Origin Document
+
+Currently, the Genesis and Configuration generator is necessary to create development `localnet` environments
+for implementing V1. A current example of this is the `make compose_and_watch` debug utility that generates a localnet
+in a `docker compose` - injecting these appropriate config.json and genesis.json files
+
+### Usage
+
+From source at project root: `go run ./build/config/main.go --numFishermen=1`
+
+From makefile at project root: `make numValidators=5 numServiceNodes=1 genesis_and_config`
+
+The files output to the `./build/config/` directory
+
+#### Parameters
+
+`numValidators` is a string flag that sets the number of validators that will be in the network, this affects the
+contents of the genesis file as well as the number of config files
+
+`numServiceNodes` is a string flag that set the number of service nodes that will be in the network's genesis file
+
+`numApplications` is a string flag that set the number of applications that will be in the network's genesis file
+
+`numFishermen` is a string flag that set the number of fishermen that will be in the network's genesis file
+
+### **NOTE**
+
+The config and genesis files located in the `./build/config/` directory are needed for `make compose_and_watch` 
+and `make client_start && make client_connect`. 
+
+These builds expect four (valdiator) config and a single genesis file.
+
+Take caution when overwriting / deleting the files with different configurations

--- a/build/config/main.go
+++ b/build/config/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"github.com/pokt-network/pocket/shared/test_artifacts"
 	"io/ioutil"
 	"log"
 	"strconv"
+
+	"github.com/pokt-network/pocket/shared/test_artifacts"
 )
 
 // Utility to generate config and genesis files
@@ -14,16 +15,16 @@ import (
 const (
 	defaultGenesisFilePath = "build/config/genesis.json"
 	defaultConfigFilePath  = "build/config/config"
-	jsonSubfix             = ".json"
+	jsonSuffix             = ".json"
 	rwoPerm                = 0777
 )
 
 var (
-	numValidators = flag.String("numValidators", "4", "set the number of validators that will be in the network, "+
+	numValidators = flag.String("numValidators", "4", "number of validators that will be in the network, "+
 		"this affects the contents of the genesis file as well as the # of config files")
-	numServiceNodes = flag.String("numServiceNodes", "1", "set the number of service nodes that will be in the network's genesis file")
-	numApplications = flag.String("numApplications", "1", "set the number of applications that will be in the network's genesis file")
-	numFishermen    = flag.String("numFishermen", "1", "set the number of fishermen that will be in the network's genesis file")
+	numServiceNodes = flag.String("numServiceNodes", "1", "number of service nodes that will be in the network's genesis file")
+	numApplications = flag.String("numApplications", "1", "number of applications that will be in the network's genesis file")
+	numFishermen    = flag.String("numFishermen", "1", "number of fishermen that will be in the network's genesis file")
 )
 
 func init() {
@@ -34,13 +35,19 @@ func main() {
 	nValidators, nServiceNodes, nFishermen, nApplications := catchEmptyFlags()
 	genesis, validatorPrivateKeys := test_artifacts.NewGenesisState(nValidators, nServiceNodes, nFishermen, nApplications)
 	configs := test_artifacts.NewDefaultConfigs(validatorPrivateKeys)
-	genesisJson, _ := json.MarshalIndent(genesis, "", "  ")
-	if err := ioutil.WriteFile(defaultGenesisFilePath, genesisJson, rwoPerm); err != nil {
+	genesisJson, err := json.MarshalIndent(genesis, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	if err = ioutil.WriteFile(defaultGenesisFilePath, genesisJson, rwoPerm); err != nil {
 		panic(err)
 	}
 	for i, config := range configs {
-		configJson, _ := json.MarshalIndent(config, "", "  ")
-		if err := ioutil.WriteFile(defaultConfigFilePath+strconv.Itoa(i+1)+jsonSubfix, configJson, rwoPerm); err != nil {
+		configJson, err := json.MarshalIndent(config, "", "  ")
+		if err != nil {
+			panic(err)
+		}
+		if err := ioutil.WriteFile(defaultConfigFilePath+strconv.Itoa(i+1)+jsonSuffix, configJson, rwoPerm); err != nil {
 			panic(err)
 		}
 	}

--- a/build/config/main.go
+++ b/build/config/main.go
@@ -13,8 +13,8 @@ import (
 // Utility to generate config and genesis files
 
 const (
-	defaultGenesisFilePath = "build/config/genesis.json"
-	defaultConfigFilePath  = "build/config/config"
+	defaultGenesisFilePath = "build/config/gen.genesis.json"
+	defaultConfigFilePath  = "build/config/gen.config"
 	jsonSuffix             = ".json"
 	rwoPerm                = 0777
 )

--- a/build/config/main.go
+++ b/build/config/main.go
@@ -2,40 +2,78 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
-
+	"flag"
 	"github.com/pokt-network/pocket/shared/test_artifacts"
+	"io/ioutil"
+	"log"
+	"strconv"
 )
 
 // Utility to generate config and genesis files
-// TODO(pocket/issues/182): Add a make target to help trigger this from cmdline
 
 const (
-	defaultGenesisFilePath = "build/config/genesis.json"
-	defaultConfigFilePath  = "build/config/config"
-	jsonSubfix             = ".json"
-	rwoPerm                = 0777
+	DefaultGenesisFilePath = "build/config/genesis.json"
+	DefaultConfigFilePath  = "build/config/config"
+	JSONSubfix             = ".json"
+	RWOPerm                = 0777
 )
 
+var (
+	numValidators = flag.String("numValidators", "4", "set the number of validators that will be in the network, "+
+		"this affects the contents of the genesis file as well as the # of config files")
+	numServiceNodes = flag.String("numServiceNodes", "1", "set the number of service nodes that will be in the network's genesis file")
+	numApplications = flag.String("numApplications", "1", "set the number of applications that will be in the network's genesis file")
+	numFishermen    = flag.String("numFishermen", "1", "set the number of fishermen that will be in the network's genesis file")
+)
+
+func init() {
+	flag.Parse()
+}
+
 func main() {
-	genesis, validatorPrivateKeys := test_artifacts.NewGenesisState(4, 1, 1, 1)
+	nValidators, nServiceNodes, nFishermen, nApplications := catchEmptyFlags()
+	genesis, validatorPrivateKeys := test_artifacts.NewGenesisState(nValidators, nServiceNodes, nFishermen, nApplications)
 	configs := test_artifacts.NewDefaultConfigs(validatorPrivateKeys)
-	genesisJson, err := json.MarshalIndent(genesis, "", "  ")
-	if err != nil {
-		panic(err)
-	}
-	if err := ioutil.WriteFile(defaultGenesisFilePath, genesisJson, rwoPerm); err != nil {
+	genesisJson, _ := json.MarshalIndent(genesis, "", "  ")
+	if err := ioutil.WriteFile(DefaultGenesisFilePath, genesisJson, RWOPerm); err != nil {
 		panic(err)
 	}
 	for i, config := range configs {
-		configJson, err := json.MarshalIndent(config, "", "  ")
-		if err != nil {
-			panic(err)
-		}
-		filePath := fmt.Sprintf("%s%d%s", defaultConfigFilePath, i+1, jsonSubfix)
-		if err := ioutil.WriteFile(filePath, configJson, rwoPerm); err != nil {
+		configJson, _ := json.MarshalIndent(config, "", "  ")
+		if err := ioutil.WriteFile(DefaultConfigFilePath+strconv.Itoa(i+1)+JSONSubfix, configJson, RWOPerm); err != nil {
 			panic(err)
 		}
 	}
+}
+
+func catchEmptyFlags() (nValidators, nServiceNodes, nFishermen, nApplications int) {
+	if *numValidators == "" {
+		*numValidators = "4"
+	}
+	if *numServiceNodes == "" {
+		*numServiceNodes = "1"
+	}
+	if *numFishermen == "" {
+		*numFishermen = "1"
+	}
+	if *numApplications == "" {
+		*numApplications = "1"
+	}
+	nValidators, err := strconv.Atoi(*numValidators)
+	if err != nil {
+		log.Fatal("an error occurred when parsing number of validators: ", err.Error())
+	}
+	nServiceNodes, err = strconv.Atoi(*numServiceNodes)
+	if err != nil {
+		log.Fatal("an error occurred when parsing number of service nodes: ", err.Error())
+	}
+	nFishermen, err = strconv.Atoi(*numFishermen)
+	if err != nil {
+		log.Fatal("an error occurred when parsing number of fishermen: ", err.Error())
+	}
+	nApplications, err = strconv.Atoi(*numApplications)
+	if err != nil {
+		log.Fatal("an error occurred when parsing number of applications: ", err.Error())
+	}
+	return
 }

--- a/build/config/main.go
+++ b/build/config/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"io/ioutil"
-	"log"
 	"strconv"
 
 	"github.com/pokt-network/pocket/shared/test_artifacts"
@@ -20,11 +19,10 @@ const (
 )
 
 var (
-	numValidators = flag.String("numValidators", "4", "number of validators that will be in the network, "+
-		"this affects the contents of the genesis file as well as the # of config files")
-	numServiceNodes = flag.String("numServiceNodes", "1", "number of service nodes that will be in the network's genesis file")
-	numApplications = flag.String("numApplications", "1", "number of applications that will be in the network's genesis file")
-	numFishermen    = flag.String("numFishermen", "1", "number of fishermen that will be in the network's genesis file")
+	numValidators   = flag.Int("numValidators", 4, "number of validators that will be in the network; this affects the contents of the genesis file as well as the # of config files")
+	numServiceNodes = flag.Int("numServiceNodes", 1, "number of service nodes that will be in the network's genesis file")
+	numApplications = flag.Int("numApplications", 1, "number of applications that will be in the network's genesis file")
+	numFishermen    = flag.Int("numFishermen", 1, "number of fishermen that will be in the network's genesis file")
 )
 
 func init() {
@@ -32,8 +30,7 @@ func init() {
 }
 
 func main() {
-	nValidators, nServiceNodes, nFishermen, nApplications := catchEmptyFlags()
-	genesis, validatorPrivateKeys := test_artifacts.NewGenesisState(nValidators, nServiceNodes, nFishermen, nApplications)
+	genesis, validatorPrivateKeys := test_artifacts.NewGenesisState(*numValidators, *numServiceNodes, *numFishermen, *numApplications)
 	configs := test_artifacts.NewDefaultConfigs(validatorPrivateKeys)
 	genesisJson, err := json.MarshalIndent(genesis, "", "  ")
 	if err != nil {
@@ -51,36 +48,4 @@ func main() {
 			panic(err)
 		}
 	}
-}
-
-func catchEmptyFlags() (nValidators, nServiceNodes, nFishermen, nApplications int) {
-	if *numValidators == "" {
-		*numValidators = "4"
-	}
-	if *numServiceNodes == "" {
-		*numServiceNodes = "1"
-	}
-	if *numFishermen == "" {
-		*numFishermen = "1"
-	}
-	if *numApplications == "" {
-		*numApplications = "1"
-	}
-	nValidators, err := strconv.Atoi(*numValidators)
-	if err != nil {
-		log.Fatal("an error occurred when parsing number of validators: ", err.Error())
-	}
-	nServiceNodes, err = strconv.Atoi(*numServiceNodes)
-	if err != nil {
-		log.Fatal("an error occurred when parsing number of service nodes: ", err.Error())
-	}
-	nFishermen, err = strconv.Atoi(*numFishermen)
-	if err != nil {
-		log.Fatal("an error occurred when parsing number of fishermen: ", err.Error())
-	}
-	nApplications, err = strconv.Atoi(*numApplications)
-	if err != nil {
-		log.Fatal("an error occurred when parsing number of applications: ", err.Error())
-	}
-	return
 }

--- a/build/config/main.go
+++ b/build/config/main.go
@@ -12,10 +12,10 @@ import (
 // Utility to generate config and genesis files
 
 const (
-	DefaultGenesisFilePath = "build/config/genesis.json"
-	DefaultConfigFilePath  = "build/config/config"
-	JSONSubfix             = ".json"
-	RWOPerm                = 0777
+	defaultGenesisFilePath = "build/config/genesis.json"
+	defaultConfigFilePath  = "build/config/config"
+	jsonSubfix             = ".json"
+	rwoPerm                = 0777
 )
 
 var (
@@ -35,12 +35,12 @@ func main() {
 	genesis, validatorPrivateKeys := test_artifacts.NewGenesisState(nValidators, nServiceNodes, nFishermen, nApplications)
 	configs := test_artifacts.NewDefaultConfigs(validatorPrivateKeys)
 	genesisJson, _ := json.MarshalIndent(genesis, "", "  ")
-	if err := ioutil.WriteFile(DefaultGenesisFilePath, genesisJson, RWOPerm); err != nil {
+	if err := ioutil.WriteFile(defaultGenesisFilePath, genesisJson, rwoPerm); err != nil {
 		panic(err)
 	}
 	for i, config := range configs {
 		configJson, _ := json.MarshalIndent(config, "", "  ")
-		if err := ioutil.WriteFile(DefaultConfigFilePath+strconv.Itoa(i+1)+JSONSubfix, configJson, RWOPerm); err != nil {
+		if err := ioutil.WriteFile(defaultConfigFilePath+strconv.Itoa(i+1)+jsonSubfix, configJson, rwoPerm); err != nil {
 			panic(err)
 		}
 	}

--- a/build/config/main.go
+++ b/build/config/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io/ioutil"
-	"strconv"
 
 	"github.com/pokt-network/pocket/shared/test_artifacts"
 )
@@ -12,10 +12,9 @@ import (
 // Utility to generate config and genesis files
 
 const (
-	defaultGenesisFilePath = "build/config/gen.genesis.json"
-	defaultConfigFilePath  = "build/config/gen.config"
-	jsonSuffix             = ".json"
-	rwoPerm                = 0777
+	defaultGenesisFilePathFormat = "build/config/%sgenesis.json"
+	defaultConfigFilePathFormat  = "build/config/%sconfig%d.json"
+	rwoPerm                      = 0777
 )
 
 var (
@@ -23,6 +22,7 @@ var (
 	numServiceNodes = flag.Int("numServiceNodes", 1, "number of service nodes that will be in the network's genesis file")
 	numApplications = flag.Int("numApplications", 1, "number of applications that will be in the network's genesis file")
 	numFishermen    = flag.Int("numFishermen", 1, "number of fishermen that will be in the network's genesis file")
+	genPrefix       = flag.String("genPrefix", "", "the prefix, if any, to append to the genesis and config files")
 )
 
 func init() {
@@ -36,7 +36,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if err = ioutil.WriteFile(defaultGenesisFilePath, genesisJson, rwoPerm); err != nil {
+	if err = ioutil.WriteFile(fmt.Sprintf(defaultGenesisFilePathFormat, *genPrefix), genesisJson, rwoPerm); err != nil {
 		panic(err)
 	}
 	for i, config := range configs {
@@ -44,7 +44,8 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		if err := ioutil.WriteFile(defaultConfigFilePath+strconv.Itoa(i+1)+jsonSuffix, configJson, rwoPerm); err != nil {
+		filePath := fmt.Sprintf(defaultConfigFilePathFormat, *genPrefix, i+1)
+		if err := ioutil.WriteFile(filePath, configJson, rwoPerm); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
## Description
In order to test various LocalNet configurations, especially as we start adding different types of protocol actors in the future, we need to be able to build such configurations easily.

An easy-to-use make target to dynamically generate genesis and config files for various LocalNet configurations. This will eventually be used for DevNet as well even though it is out of scope of this PR.

## Issue

Fixes #182 

## Type of change

Please mark the options that are relevant.

- [x] New feature, functionality or library
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other: <REPLACE_ME>

## List of changes
- [x] Added make target for genesis and config generation in `build/config`
- [x] Document parameters and usage with `README.md`

## Testing
- [x] `make test_all`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`
- [x] `make genesis_and_config`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] If applicable, I have made corresponding changes to related local or global README

Co-authored-by: Andrew Nguyen <andrewnguyen@Andrews-MacBook-Pro-2.local>
Co-authored-by: Daniel Olshansky <olshansky.daniel@gmail.com>