### PR TITLE
[P2P]: BenchmarkAddrBookUpdates updated to actually update the addressbook - Issue #242

### DIFF
--- a/p2p/raintree/addrbook_utils_test.go
+++ b/p2p/raintree/addrbook_utils_test.go
@@ -109,8 +109,8 @@ func BenchmarkAddrBookUpdates(b *testing.B) {
 			err = network.processAddrBookUpdates()
 			require.NoError(b, err)
 
-			require.Equal(b, n, len(network.addrList), n)
-			require.Equal(b, n, len(network.addrBookMap), n)
+			require.Equal(b, n, len(network.addrList))
+			require.Equal(b, n, len(network.addrBookMap))
 			require.Equal(b, testCase.numExpectedLevels, int(network.maxNumLevels))
 
 			for i := 0; i < numAddressessToBeAdded; i++ {


### PR DESCRIPTION
## Description

I am doing some refactoring work on P2P and I think I have optimized greatly address book updates.
While doing that, I noticed that this benchmark is not really updating the addressbook when it's created.

I have therefore added some extra work that -should- grow linearly with `n`.

## Issue

Fixes [issue/242](https://github.com/pokt-network/pocket/issues/242)

## Type of change

Please mark the options that are relevant.

- [x] Code health or cleanup

## List of changes

- added arbitrary number of updates to the existing addressbook

## Testing

- _\_\_REPLACE_ME_: Describe the tests and steps that you ran to verify your changes. Bonus points for images and videos or gifs.\_
- [ ] `make test_all`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] If applicable, I have made corresponding changes to related local or global README
- [x] If applicable, I have added new diagrams using [mermaid.js](https://mermaid-js.github.io)
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
