### PR TITLE
[TECHDEBT] [P2P] Moved p2p telemetry metrics into telemetry module

### DIFF
--- a/p2p/module.go
+++ b/p2p/module.go
@@ -9,14 +9,13 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/pokt-network/pocket/shared/debug"
-
 	"github.com/pokt-network/pocket/p2p/raintree"
 	"github.com/pokt-network/pocket/p2p/stdnetwork"
-	p2pTelemetry "github.com/pokt-network/pocket/p2p/telemetry"
 	typesP2P "github.com/pokt-network/pocket/p2p/types"
 	cryptoPocket "github.com/pokt-network/pocket/shared/crypto"
+	"github.com/pokt-network/pocket/shared/debug"
 	"github.com/pokt-network/pocket/shared/modules"
+	"github.com/pokt-network/pocket/telemetry"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -116,8 +115,8 @@ func (m *p2pModule) Start() error {
 		GetTelemetryModule().
 		GetTimeSeriesAgent().
 		CounterRegister(
-			p2pTelemetry.P2P_NODE_STARTED_TIMESERIES_METRIC_NAME,
-			p2pTelemetry.P2P_NODE_STARTED_TIMESERIES_METRIC_DESCRIPTION,
+			telemetry.P2P_NODE_STARTED_TIMESERIES_METRIC_NAME,
+			telemetry.P2P_NODE_STARTED_TIMESERIES_METRIC_DESCRIPTION,
 		)
 
 	addrBook, err := ValidatorMapToAddrBook(m.p2pConfig, m.bus.GetConsensusModule().ValidatorMap())
@@ -145,7 +144,7 @@ func (m *p2pModule) Start() error {
 	m.GetBus().
 		GetTelemetryModule().
 		GetTimeSeriesAgent().
-		CounterIncrement(p2pTelemetry.P2P_NODE_STARTED_TIMESERIES_METRIC_NAME)
+		CounterIncrement(telemetry.P2P_NODE_STARTED_TIMESERIES_METRIC_NAME)
 
 	return nil
 }

--- a/p2p/raintree/network.go
+++ b/p2p/raintree/network.go
@@ -6,12 +6,11 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/pokt-network/pocket/shared/debug"
-
-	p2pTelemetry "github.com/pokt-network/pocket/p2p/telemetry"
 	typesP2P "github.com/pokt-network/pocket/p2p/types"
 	cryptoPocket "github.com/pokt-network/pocket/shared/crypto"
+	"github.com/pokt-network/pocket/shared/debug"
 	"github.com/pokt-network/pocket/shared/modules"
+	telemetry "github.com/pokt-network/pocket/telemetry"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -145,9 +144,9 @@ func (n *rainTreeNetwork) HandleNetworkData(data []byte) ([]byte, error) {
 		GetTelemetryModule().
 		GetEventMetricsAgent().
 		EmitEvent(
-			p2pTelemetry.P2P_EVENT_METRICS_NAMESPACE,
-			p2pTelemetry.RAINTREE_MESSAGE_EVENT_METRIC_NAME,
-			p2pTelemetry.RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
+			telemetry.P2P_EVENT_METRICS_NAMESPACE,
+			telemetry.RAINTREE_MESSAGE_EVENT_METRIC_NAME,
+			telemetry.RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
 		)
 
 	var rainTreeMsg typesP2P.RainTreeMessage
@@ -176,10 +175,10 @@ func (n *rainTreeNetwork) HandleNetworkData(data []byte) ([]byte, error) {
 			GetTelemetryModule().
 			GetEventMetricsAgent().
 			EmitEvent(
-				p2pTelemetry.P2P_EVENT_METRICS_NAMESPACE,
-				p2pTelemetry.BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME,
-				p2pTelemetry.RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL, rainTreeMsg.Nonce,
-				p2pTelemetry.RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
+				telemetry.P2P_EVENT_METRICS_NAMESPACE,
+				telemetry.BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME,
+				telemetry.RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL, rainTreeMsg.Nonce,
+				telemetry.RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
 			)
 
 		return nil, nil

--- a/p2p/raintree/network.go
+++ b/p2p/raintree/network.go
@@ -145,8 +145,8 @@ func (n *rainTreeNetwork) HandleNetworkData(data []byte) ([]byte, error) {
 		GetEventMetricsAgent().
 		EmitEvent(
 			telemetry.P2P_EVENT_METRICS_NAMESPACE,
-			telemetry.RAINTREE_MESSAGE_EVENT_METRIC_NAME,
-			telemetry.RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
+			telemetry.P2P_RAINTREE_MESSAGE_EVENT_METRIC_NAME,
+			telemetry.P2P_RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
 		)
 
 	var rainTreeMsg typesP2P.RainTreeMessage
@@ -176,9 +176,9 @@ func (n *rainTreeNetwork) HandleNetworkData(data []byte) ([]byte, error) {
 			GetEventMetricsAgent().
 			EmitEvent(
 				telemetry.P2P_EVENT_METRICS_NAMESPACE,
-				telemetry.BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME,
-				telemetry.RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL, rainTreeMsg.Nonce,
-				telemetry.RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
+				telemetry.P2P_BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME,
+				telemetry.P2P_RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL, rainTreeMsg.Nonce,
+				telemetry.P2P_RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL, blockHeight,
 			)
 
 		return nil, nil

--- a/p2p/telemetry/metrics.go
+++ b/p2p/telemetry/metrics.go
@@ -1,1 +1,0 @@
-package p2p_telemetry

--- a/p2p/telemetry/metrics.go
+++ b/p2p/telemetry/metrics.go
@@ -1,19 +1,1 @@
 package p2p_telemetry
-
-// TODO (Team) move to telemetry module
-
-const (
-	// Time Series Metrics
-	P2P_NODE_STARTED_TIMESERIES_METRIC_NAME        = "p2p_nodes_started_counter"
-	P2P_NODE_STARTED_TIMESERIES_METRIC_DESCRIPTION = "the counter to track the number of nodes online"
-
-	// Event Metrics
-	P2P_EVENT_METRICS_NAMESPACE = "event_metrics_namespace_p2p"
-
-	BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME = "broadcast_message_redundancy_per_block_event_metric"
-	RAINTREE_MESSAGE_EVENT_METRIC_NAME                       = "raintree_message_event_metric"
-
-	// Attributes
-	RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL = "height"
-	RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL  = "nonce"
-)

--- a/telemetry/metrics_p2p.go
+++ b/telemetry/metrics_p2p.go
@@ -8,10 +8,10 @@ const (
 	// Event Metrics
 	P2P_EVENT_METRICS_NAMESPACE = "event_metrics_namespace_p2p"
 
-	BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME = "broadcast_message_redundancy_per_block_event_metric"
-	RAINTREE_MESSAGE_EVENT_METRIC_NAME                       = "raintree_message_event_metric"
+	P2P_BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME = "broadcast_message_redundancy_per_block_event_metric"
+	P2P_RAINTREE_MESSAGE_EVENT_METRIC_NAME                       = "raintree_message_event_metric"
 
 	// Attributes
-	RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL = "height"
-	RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL  = "nonce"
+	P2P_RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL = "height"
+	P2P_RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL  = "nonce"
 )

--- a/telemetry/metrics_p2p.go
+++ b/telemetry/metrics_p2p.go
@@ -1,0 +1,17 @@
+package telemetry
+
+const (
+	// Time Series Metrics
+	P2P_NODE_STARTED_TIMESERIES_METRIC_NAME        = "p2p_nodes_started_counter"
+	P2P_NODE_STARTED_TIMESERIES_METRIC_DESCRIPTION = "the counter to track the number of nodes online"
+
+	// Event Metrics
+	P2P_EVENT_METRICS_NAMESPACE = "event_metrics_namespace_p2p"
+
+	BROADCAST_MESSAGE_REDUNDANCY_PER_BLOCK_EVENT_METRIC_NAME = "broadcast_message_redundancy_per_block_event_metric"
+	RAINTREE_MESSAGE_EVENT_METRIC_NAME                       = "raintree_message_event_metric"
+
+	// Attributes
+	RAINTREE_MESSAGE_EVENT_METRIC_HEIGHT_LABEL = "height"
+	RAINTREE_MESSAGE_EVENT_METRIC_NONCE_LABEL  = "nonce"
+)


### PR DESCRIPTION
Tending to the TODO item:

https://github.com/pokt-network/pocket/blob/5b958411177d1ae0a16da8354555d53fe6a7e306/p2p/telemetry/metrics.go#L3

it also renames the constants by making them have "P2P" as prefix so that constants from various modules can be easily identified while developing.

## Thoughts

Having metrics labels defined inside the `telemetry` module makes sense, however, that means that the `telemetry` module knows about some strings belonging to some other module that have some sort of meaning. `telemetry` is still pretty ignorant about the implementation details of the other modules but there's some interdependency. 
It also means that now `p2p` imports `telemetry`.

🤔
