### PR TITLE
[Consensus] LocalNet doesn't work properly: debug messages not processed

### DIFF
--- a/consensus/debugging.go
+++ b/consensus/debugging.go
@@ -9,8 +9,6 @@ import (
 )
 
 func (m *ConsensusModule) HandleDebugMessage(debugMessage *debug.DebugMessage) error {
-	m.m.Lock()
-	defer m.m.Unlock()
 	switch debugMessage.Action {
 	case debug.DebugMessageAction_DEBUG_CONSENSUS_RESET_TO_GENESIS:
 		m.resetToGenesis(debugMessage)


### PR DESCRIPTION
## Description

Localnet starts correctly but messages from the client are not handled. This PR fixes that.

### Explainer

We need the locks in the first place because the testing harness is simulating multiple nodes running at the same time and therefore we have race conditions (since goroutines are involved).

In the realm of LocalNet, where each node is its own environment with isolation (docker containers), when we handle a debug message, we don't have any contention because there's only one goroutine doing the work.

Specifically, the **deadlock** came from the fact that, for example, `printNodeState` internally calls `GetNodeState` which again locks the mutex.

## Type of change

Please mark the relevant option(s):

- [x] Bug fix

## List of changes

- removed a misplaced `lock` that caused a deadlock.

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`
<!--
If you added additional tests or infrastructure, describe it here.

Bonus points for images and videos or gifs.
-->

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [x] I have updated the corresponding README(s); local and/or global
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [x] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
