### PR TITLE
[One line change] Enable pushing images to container registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ env:
   # Even though we can test against multiple versions, this one is considered a target version.
   TARGET_GOLANG_VERSION: "1.19"
   PROTOC_VERSION: "3.19.4"
-  PUSH_TO_DOCKERHUB: false
 
 jobs:
   test-multiple-go-versions:
@@ -102,14 +101,12 @@ jobs:
             type=sha${{ matrix.imageType == 'dev' && ',suffix=-dev' || '' }}
             type=raw,value=latest,enable={{is_default_branch}}${{ matrix.imageType == 'dev' && ',suffix=-dev' || '' }}
       - name: Login to GitHub Container Registry
-        if: ${{ env.PUSH_TO_DOCKERHUB != 'false' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
-        if: ${{ env.PUSH_TO_DOCKERHUB != 'false' }}
         uses: docker/build-push-action@v3
         with:
           push: true


### PR DESCRIPTION
<!--
 1. Make the title of the PR is descriptive and follows this format: `[<Module>] <DESCRIPTION>`
 2. Update the _Assigness_, _Labels_, _Projects_, _Milestone_ before submitting the PR for review.
 3. Add label(s) for the purpose (e.g. `persistence`) and, if applicable, priority (e.g. `low`) labels as well.
-->

## Description

We originally turned off pushing images to the registries (we had ghcr.io and docker hub in a rotation) due to issues on docker hub side. We've removed docker hub from the rotation, so we can now continue pushing images just to ghcr.io.

<!--
1. Add a summary of the change including: motivation, reasons, context, dependencies, etc...
2. If applicable, specify the key files that should be looked at.
-->

## Issue

Fixes upload to the container registry.

## Type of change

Please mark the relevant option(s):

- [x] Other - quick CI modification

## List of changes

<!-- List out all the changes made-->

- removed action condition that prevented a container registry push

## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

