### PR TITLE
[quick change] remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default Reviewers for all PRs
-*     @pokt-network/engineering-member


### PR DESCRIPTION
<!--
 1. Make the title of the PR is descriptive and follows this format: `[<Module>] <DESCRIPTION>`
 2. Update the _Assigness_, _Labels_, _Projects_, _Milestone_ before submitting the PR for review.
 3. Add label(s) for the purpose (e.g. `persistence`) and, if applicable, priority (e.g. `low`) labels as well.
-->

## Description

Code owners were originally set up to assign all protocol engineers to all new PRs, but since we have more people on the team focusing on different kind of work, we no longer need to request review from the whole team. We are generally good at requesting the reviews from team members.

We can add it back later with more granular configuration (e.g. specific modules must be reviewed by selected engineers) when repo stabilizes.

<!--
1. Add a summary of the change including: motivation, reasons, context, dependencies, etc...
2. If applicable, specify the key files that should be looked at.
-->

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [x] GitHub configuration

## List of changes

- CODEOWNERS file removed
