### PR TITLE
[Quick CI change]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,9 @@ jobs:
   # - figure out how to handle musl/alpine case if we want to support it
   build-images:
     runs-on: ubuntu-latest
+    needs: test-multiple-go-versions
+    # Until we have developer environments, we don't need the images built on other that main branches.
+    if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
         # Build dev & prod images


### PR DESCRIPTION
Only build images for main branch until we have remote developer environments, when the images from other branches will be useful.