### PR TITLE
[DX] Dangling mocks cause errors when building/testing a branch after switching from another - Issue #369

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ docker_wipe_nodes: docker_check prompt_user db_drop
 monitoring_start: docker_check
 	docker-compose -f build/deployments/docker-compose.yaml up --no-recreate -d grafana loki vm
 
-.PHONY: make docker_loki_install
+.PHONY: docker_loki_install
 ## Installs the loki docker driver
 docker_loki_install: docker_check
 	docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ install_cli_deps:
 .PHONY: develop_start
 ## Run all of the make commands necessary to develop on the project
 develop_start:
+		make clean_mocks && \
 		make protogen_clean && make protogen_local && \
 		make go_clean_deps && \
 		make mockgen && \
@@ -226,11 +227,15 @@ monitoring_start: docker_check
 docker_loki_install: docker_check
 	docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
 
-.PHONY: mockgen
-## Use `mockgen` to generate mocks used for testing purposes of all the modules.
-mockgen:
+clean_mocks:
+### Use `clean_mocks` delete mocks before recreating them. Also useful to cleanup code that was generated from a differen branch
 	$(eval modules_dir = "shared/modules")
 	find ${modules_dir}/mocks -maxdepth 1 -type f ! -name "mocks.go" -exec rm {} \;
+
+.PHONY: mockgen
+## Use `mockgen` to generate mocks used for testing purposes of all the modules.
+mockgen: clean_mocks
+	$(eval modules_dir = "shared/modules")
 	go generate ./${modules_dir}
 	echo "Mocks generated in ${modules_dir}/mocks"
 

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ docker_loki_install: docker_check
 ### Use `clean_mocks` to delete mocks before recreating them. Also useful to cleanup code that was generated from a different branch
 clean_mocks:
 	$(eval modules_dir = "shared/modules")
-	find ${modules_dir}/mocks -maxdepth 1 -type f ! -name "mocks.go" -exec rm {} \;
+	find ${modules_dir}/mocks -type f ! -name "mocks.go" -exec rm {} \;
 
 .PHONY: mockgen
 ## Use `mockgen` to generate mocks used for testing purposes of all the modules.

--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,8 @@ monitoring_start: docker_check
 docker_loki_install: docker_check
 	docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
 
+### Use `clean_mocks` to delete mocks before recreating them. Also useful to cleanup code that was generated from a different branch
 clean_mocks:
-### Use `clean_mocks` delete mocks before recreating them. Also useful to cleanup code that was generated from a differen branch
 	$(eval modules_dir = "shared/modules")
 	find ${modules_dir}/mocks -maxdepth 1 -type f ! -name "mocks.go" -exec rm {} \;
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERBOSE_TEST ?= -v
 
 help:
 	printf "Available targets\n\n"
-	awk '/^[a-zA-Z\-\_0-9]+:/ { \
+	awk '/^[a-zA-Z\-\\_0-9]+:/ { \
 		helpMessage = match(lastLine, /^## (.*)/); \
 		if (helpMessage) { \
 			helpCommand = substr($$1, 0, index($$1, ":")-1); \

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ monitoring_start: docker_check
 docker_loki_install: docker_check
 	docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
 
+.PHONY: clean_mocks
 ### Use `clean_mocks` to delete mocks before recreating them. Also useful to cleanup code that was generated from a different branch
 clean_mocks:
 	$(eval modules_dir = "shared/modules")
@@ -292,12 +293,13 @@ generate_rpc_openapi: go_oapi-codegen
 	oapi-codegen  --config ./rpc/client.gen.config.yml ./rpc/v1/openapi.yaml > ./rpc/client.gen.go
 	echo "OpenAPI client and server generated"
 
+.PHONY: swagger-ui
 ## Starts a local Swagger UI instance for the RPC API
 swagger-ui:
 	echo "Attempting to start Swagger UI at http://localhost:8080\n\n"
 	docker run -p 8080:8080 -e SWAGGER_JSON=/v1/openapi.yaml -v $(shell pwd)/rpc/v1:/v1 swaggerapi/swagger-ui
-.PHONY: generate_cli_commands_docs
 
+.PHONY: generate_cli_commands_docs
 ### (Re)generates the CLI commands docs (this is meant to be called by CI)
 generate_cli_commands_docs:
 	$(eval cli_docs_dir = "app/client/cli/doc/commands")


### PR DESCRIPTION
## Description

This PR makes sure that mocks are cleared before rebuilding/testing the current branch

## Issue

Fixes #369

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Makefile target to clean mocks
- Calling the new Makefile target where required

## Testing

- [x] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`
<!--
If you added additional tests or infrastructure, describe it here.

Bonus points for images and videos or gifs.
-->

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

