### PR TITLE
[Quick CI fix] sanitize json test results before triggering annotation action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,16 +55,15 @@ jobs:
         run: |
           set -euo pipefail
           go test -p 1 -json ./... -covermode=count -coverprofile=coverage.out 2>&1 | tee test_results.json
-      - name: Output test failures
-        # Makes it easier to find failed tests so no need to scroll through the whole log.
-        if: ${{ failure() && env.TARGET_GOLANG_VERSION == matrix.go }}
-        run: |
-          cat test_results.json | jq 'select(.Action == "fail")'
+
       - name: Sanitize test results
         # We're utilizing `tee` above which can capture non-json stdout output, we also need to remove non-json lines.
         if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}
-        run: |
-          cat test_results.json | jq -c -R 'fromjson? | select(type == "object")' > tmp.json && mv tmp.json test_results.json
+        run: cat test_results.json | jq -c -R 'fromjson? | select(type == "object")' > tmp.json && mv tmp.json test_results.json
+      - name: Output test failures
+        # Makes it easier to find failed tests so no need to scroll through the whole log.
+        if: ${{ failure() && env.TARGET_GOLANG_VERSION == matrix.go }}
+        run: cat test_results.json | jq 'select(.Action == "fail")'
       - name: Upload test results
         if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           set -euo pipefail
           go test -p 1 -json ./... -covermode=count -coverprofile=coverage.out 2>&1 | tee test_results.json
       - name: Sanitize test results
-        # We're utilizing `tee` above which can capture non-json stdout output, we also need to remove non-json lines.
+        # We're utilizing `tee` above which can capture non-json stdout output so we need to remove non-json lines before additional parsing and submitting it to the external github action.
         if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}
         run: cat test_results.json | jq -c -R 'fromjson? | select(type == "object")' > tmp.json && mv tmp.json test_results.json
       - name: Output test failures

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,13 @@ jobs:
       - name: Output test failures
         # Makes it easier to find failed tests so no need to scroll through the whole log.
         if: ${{ failure() && env.TARGET_GOLANG_VERSION == matrix.go }}
-        run: cat test_results.json | jq 'select(.Action == "fail")'
+        run: |
+          cat test_results.json | jq 'select(.Action == "fail")'
+      - name: Sanitize test results
+        # We're utilizing `tee` above which can capture non-json stdout output, we also need to remove non-json lines.
+        if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}
+        run: |
+          cat test_results.json | jq -c -R 'fromjson? | select(type == "object")' > tmp.json && mv tmp.json test_results.json
       - name: Upload test results
         if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           set -euo pipefail
           go test -p 1 -json ./... -covermode=count -coverprofile=coverage.out 2>&1 | tee test_results.json
-
       - name: Sanitize test results
         # We're utilizing `tee` above which can capture non-json stdout output, we also need to remove non-json lines.
         if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}


### PR DESCRIPTION
<!--
 1. Make the title of the PR is descriptive and follows this format: `[<Module>] <DESCRIPTION>`
 2. Update the _Assigness_, _Labels_, _Projects_, _Milestone_ before submitting the PR for review.
 3. Add label(s) for the purpose (e.g. `persistence`) and, if applicable, priority (e.g. `low`) labels as well.
-->

## Description

As we're using `tee` to pipe results of the tests to stdout and to `test_results.json` we need to sanitize what actually gets into that file, because non-json text breaks actions that expect json (obviously).
<!--
1. Add a summary of the change including: motivation, reasons, context, dependencies, etc...
2. If applicable, specify the key files that should be looked at.
-->


