### PR TITLE
[Utility] Fix flaky tests `TestUtilityContext_ApplyBlock` and `TestUtilityContext_EndBlock`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ install_cli_deps:
 	go install "github.com/golang/mock/mockgen@v1.6.0" && mockgen --version
 	go install "github.com/favadi/protoc-go-inject-tag@latest"
 	go install "github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.11.0"
-	go install github.com/go-delve/delve/cmd/dlv@latest
 
 .PHONY: develop_start
 ## Run all of the make commands necessary to develop on the project

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ install_cli_deps:
 	go install "github.com/golang/mock/mockgen@v1.6.0" && mockgen --version
 	go install "github.com/favadi/protoc-go-inject-tag@latest"
 	go install "github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.11.0"
+	go install github.com/go-delve/delve/cmd/dlv@latest
 
 .PHONY: develop_start
 ## Run all of the make commands necessary to develop on the project

--- a/persistence/indexer/indexer_test.go
+++ b/persistence/indexer/indexer_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	shared "github.com/pokt-network/pocket/shared/modules"
-
 	"github.com/pokt-network/pocket/shared/crypto"
+	shared "github.com/pokt-network/pocket/shared/modules"
 	"github.com/stretchr/testify/require"
 )
 

--- a/persistence/indexer/indexer_test.go
+++ b/persistence/indexer/indexer_test.go
@@ -1,11 +1,12 @@
 package indexer
 
 import (
-	shared "github.com/pokt-network/pocket/shared/modules"
 	"log"
 	"math/rand"
 	"testing"
 	"time"
+
+	shared "github.com/pokt-network/pocket/shared/modules"
 
 	"github.com/pokt-network/pocket/shared/crypto"
 	"github.com/stretchr/testify/require"

--- a/persistence/validator.go
+++ b/persistence/validator.go
@@ -104,17 +104,17 @@ func (p PostgresContext) GetValidatorOutputAddress(operator []byte, height int64
 	return p.GetActorOutputAddress(types.ValidatorActor, operator, height)
 }
 
-// TODO(team): implement missed blocks
+// TODO: implement missed blocks
 func (p PostgresContext) SetValidatorPauseHeightAndMissedBlocks(address []byte, pausedHeight int64, missedBlocks int) error {
 	return nil
 }
 
-// TODO(team): implement missed blocks
+// TODO: implement missed blocks
 func (p PostgresContext) SetValidatorMissedBlocks(address []byte, missedBlocks int) error {
 	return nil
 }
 
-// TODO(team): implement missed blocks
+// TODO: implement missed blocks
 func (p PostgresContext) GetValidatorMissedBlocks(address []byte, height int64) (int, error) {
 	return 0, nil
 }

--- a/runtime/defaults/defaults.go
+++ b/runtime/defaults/defaults.go
@@ -13,6 +13,7 @@ const (
 	defaultRPCTimeout = 30000
 )
 
+// TODO: some of these defaults are used for production while others are used for testing. Need to separate them.
 var (
 	DefaultChains              = []string{"0001"}
 	DefaultServiceURL          = ""
@@ -22,6 +23,8 @@ var (
 	DefaultMaxRelaysString     = converters.BigIntToString(DefaultMaxRelays)
 	DefaultAccountAmount       = big.NewInt(100000000000000)
 	DefaultAccountAmountString = converters.BigIntToString(DefaultAccountAmount)
+	DefaultSendAmount          = big.NewInt(10000)
+	DefaultSendAmountString    = converters.BigIntToString(DefaultSendAmount)
 	DefaultPauseHeight         = int64(-1)
 	DefaultUnstakingHeight     = int64(-1)
 	DefaultChainID             = "testnet"

--- a/runtime/defaults/defaults.go
+++ b/runtime/defaults/defaults.go
@@ -23,8 +23,6 @@ var (
 	DefaultMaxRelaysString     = converters.BigIntToString(DefaultMaxRelays)
 	DefaultAccountAmount       = big.NewInt(100000000000000)
 	DefaultAccountAmountString = converters.BigIntToString(DefaultAccountAmount)
-	DefaultSendAmount          = big.NewInt(10000)
-	DefaultSendAmountString    = converters.BigIntToString(DefaultSendAmount)
 	DefaultPauseHeight         = int64(-1)
 	DefaultUnstakingHeight     = int64(-1)
 	DefaultChainID             = "testnet"

--- a/utility/test/actor_test.go
+++ b/utility/test/actor_test.go
@@ -487,84 +487,83 @@ func TestUtilityContext_UnstakeActorsThatAreReady(t *testing.T) {
 			ctx := NewTestingUtilityContext(t, 1)
 
 			var poolName string
-			var err1, err2 error
 			switch actorType {
 			case typesUtil.ActorType_App:
-				err1 = ctx.Context.SetParam(typesUtil.AppUnstakingBlocksParamName, 0)
-				err2 = ctx.Context.SetParam(typesUtil.AppMaxPauseBlocksParamName, 0)
 				poolName = typesUtil.PoolNames_AppStakePool.String()
 			case typesUtil.ActorType_Validator:
-				err1 = ctx.Context.SetParam(typesUtil.ValidatorUnstakingBlocksParamName, 0)
-				err2 = ctx.Context.SetParam(typesUtil.ValidatorMaxPausedBlocksParamName, 0)
 				poolName = typesUtil.PoolNames_ValidatorStakePool.String()
 			case typesUtil.ActorType_Fisherman:
-				err1 = ctx.Context.SetParam(typesUtil.FishermanUnstakingBlocksParamName, 0)
-				err2 = ctx.Context.SetParam(typesUtil.FishermanMaxPauseBlocksParamName, 0)
 				poolName = typesUtil.PoolNames_FishermanStakePool.String()
 			case typesUtil.ActorType_ServiceNode:
-				err1 = ctx.Context.SetParam(typesUtil.ServiceNodeUnstakingBlocksParamName, 0)
-				err2 = ctx.Context.SetParam(typesUtil.ServiceNodeMaxPauseBlocksParamName, 0)
 				poolName = typesUtil.PoolNames_ServiceNodeStakePool.String()
 			default:
 				t.Fatalf("unexpected actor type %s", actorType.String())
 			}
-			require.NoError(t, err1, "error setting unstaking blocks")
-			require.NoError(t, err2, "error setting max pause blocks")
+			ctx.SetPoolAmount(poolName, big.NewInt(math.MaxInt64))
 
-			err := ctx.SetPoolAmount(poolName, big.NewInt(math.MaxInt64))
+			err := ctx.Context.SetParam(typesUtil.AppUnstakingBlocksParamName, 0)
+			require.NoError(t, err)
+
+			err = ctx.Context.SetParam(typesUtil.AppMaxPauseBlocksParamName, 0)
 			require.NoError(t, err)
 
 			actors := getAllTestingActors(t, ctx, actorType)
 			for _, actor := range actors {
-				addrBz, err := hex.DecodeString(actor.GetAddress())
-				require.NoError(t, err)
-				require.Equal(t, int64(-1), actor.GetUnstakingHeight(), "wrong starting staked status")
-				err = ctx.SetActorPauseHeight(actorType, addrBz, 1)
-				require.NoError(t, err, "error setting actor pause height")
+				// require.Equal(t, int32(typesUtil.StakedStatus), actor.GetStatus(), "wrong starting status")
+				addrBz, er := hex.DecodeString(actor.GetAddress())
+				require.NoError(t, er)
+				er = ctx.SetActorPauseHeight(actorType, addrBz, 1)
+				require.NoError(t, er)
 			}
 
 			err = ctx.UnstakeActorPausedBefore(2, actorType)
-			require.NoError(t, err, "error setting actor pause before")
-
-			accountAmountsBefore := make([]*big.Int, 0)
-			for _, actor := range actors {
-				// get the output address account amount before the 'unstake'
-				outputAddressString := actor.GetOutput()
-				outputAddress, err := hex.DecodeString(outputAddressString)
-				require.NoError(t, err)
-				outputAccountAmount, err := ctx.GetAccountAmount(outputAddress)
-				require.NoError(t, err)
-				// capture the amount before
-				accountAmountsBefore = append(accountAmountsBefore, outputAccountAmount)
-			}
-			// capture the pool amount before
-			poolAmountBefore, err := ctx.GetPoolAmount(poolName)
 			require.NoError(t, err)
 
 			err = ctx.UnstakeActorsThatAreReady()
-			require.NoError(t, err, "error unstaking actors that are ready")
-
-			for i, actor := range actors {
-				// get the output address account amount after the 'unstake'
-				outputAddressString := actor.GetOutput()
-				outputAddress, err := hex.DecodeString(outputAddressString)
-				require.NoError(t, err)
-
-				outputAccountAmount, err := ctx.GetAccountAmount(outputAddress)
-				require.NoError(t, err)
-
-				// ensure the stake amount went to the output address
-				outputAccountAmountDelta := new(big.Int).Sub(outputAccountAmount, accountAmountsBefore[i])
-				require.Equal(t, outputAccountAmountDelta, defaults.DefaultStakeAmount)
-			}
-
-			// ensure the staking pool is `# of readyToUnstake actors * default stake` less than before the unstake
-			poolAmountAfter, err := ctx.GetPoolAmount(poolName)
 			require.NoError(t, err)
 
-			actualPoolDelta := new(big.Int).Sub(poolAmountBefore, poolAmountAfter)
-			expectedPoolDelta := new(big.Int).Mul(big.NewInt(int64(len(actors))), defaults.DefaultStakeAmount)
-			require.Equal(t, expectedPoolDelta, actualPoolDelta)
+			actors = getAllTestingActors(t, ctx, actorType)
+			require.NotEqual(t, actors[0].GetUnstakingHeight(), -1, "validators still exists after unstake that are ready() call")
+
+			// TODO: We need to better define what 'deleted' really is in the postgres world.
+			// We might not need to 'unstakeActorsThatAreReady' if we are already filtering by unstakingHeight
+			test_artifacts.CleanupTest(ctx)
+		})
+	}
+}
+
+func TestUtilityContext_BeginUnstakingMaxPausedActors(t *testing.T) {
+	for _, actorType := range actorTypes {
+		t.Run(fmt.Sprintf("%s.BeginUnstakingMaxPausedActors", actorType.String()), func(t *testing.T) {
+			ctx := NewTestingUtilityContext(t, 1)
+			actor := getFirstActor(t, ctx, actorType)
+
+			var err error
+			switch actorType {
+			case typesUtil.ActorType_App:
+				err = ctx.Context.SetParam(typesUtil.AppMaxPauseBlocksParamName, 0)
+			case typesUtil.ActorType_Validator:
+				err = ctx.Context.SetParam(typesUtil.ValidatorMaxPausedBlocksParamName, 0)
+			case typesUtil.ActorType_Fisherman:
+				err = ctx.Context.SetParam(typesUtil.FishermanMaxPauseBlocksParamName, 0)
+			case typesUtil.ActorType_ServiceNode:
+				err = ctx.Context.SetParam(typesUtil.ServiceNodeMaxPauseBlocksParamName, 0)
+			default:
+				t.Fatalf("unexpected actor type %s", actorType.String())
+			}
+			require.NoError(t, err)
+
+			addrBz, er := hex.DecodeString(actor.GetAddress())
+			require.NoError(t, er)
+
+			err = ctx.SetActorPauseHeight(actorType, addrBz, 0)
+			require.NoError(t, err)
+
+			err = ctx.BeginUnstakingMaxPaused()
+			require.NoError(t, err)
+
+			status, err := ctx.GetActorStatus(actorType, addrBz)
+			require.Equal(t, int32(typesUtil.StakeStatus_Unstaking), status, "incorrect status")
 
 			test_artifacts.CleanupTest(ctx)
 		})

--- a/utility/test/block_test.go
+++ b/utility/test/block_test.go
@@ -2,8 +2,6 @@ package test
 
 import (
 	"encoding/hex"
-	"fmt"
-	"math"
 	"math/big"
 	"testing"
 
@@ -14,22 +12,25 @@ import (
 
 func TestUtilityContext_ApplyBlock(t *testing.T) {
 	ctx := NewTestingUtilityContext(t, 0)
-	tx, startingBalance, amount, signer := newTestingTransaction(t, ctx)
+	tx, startingBalance, amountSent, signer := newTestingTransaction(t, ctx)
 
-	vals := getAllTestingValidators(t, ctx)
-	proposer := vals[0]
-
-	txBz, err := tx.Bytes()
-	require.NoError(t, err)
-	addrBz, er := hex.DecodeString(proposer.GetAddress())
+	txBz, er := tx.Bytes()
 	require.NoError(t, er)
+
+	proposer := getFirstActor(t, ctx, typesUtil.ActorType_Validator)
+
+	addrBz, err := hex.DecodeString(proposer.GetAddress())
+	require.NoError(t, err)
+
 	proposerBeforeBalance, err := ctx.GetAccountAmount(addrBz)
 	require.NoError(t, err)
-	er = ctx.GetPersistenceContext().SetProposalBlock("", addrBz, nil, [][]byte{txBz})
-	require.NoError(t, er)
-	// apply block
-	_, er = ctx.ApplyBlock()
-	require.NoError(t, er)
+
+	err = ctx.GetPersistenceContext().SetProposalBlock("", addrBz, nil, [][]byte{txBz})
+	require.NoError(t, err)
+
+	appHash, err := ctx.ApplyBlock()
+	require.NoError(t, err)
+	require.NotNil(t, appHash)
 
 	// // TODO: Uncomment this once `GetValidatorMissedBlocks` is implemented.
 	// beginBlock logic verify
@@ -37,16 +38,14 @@ func TestUtilityContext_ApplyBlock(t *testing.T) {
 	// require.NoError(t, err)
 	// require.Equal(t, missed, 1)
 
-	// deliverTx logic verify
 	feeBig, err := ctx.GetMessageSendFee()
 	require.NoError(t, err)
 
-	expectedAmountSubtracted := big.NewInt(0).Add(amount, feeBig)
+	expectedAmountSubtracted := big.NewInt(0).Add(amountSent, feeBig)
 	expectedAfterBalance := big.NewInt(0).Sub(startingBalance, expectedAmountSubtracted)
 	amountAfter, err := ctx.GetAccountAmount(signer.Address())
 	require.NoError(t, err)
 	require.Equal(t, expectedAfterBalance, amountAfter, "unexpected after balance; expected %v got %v", expectedAfterBalance, amountAfter)
-	// end-block logic verify
 
 	proposerCutPercentage, err := ctx.GetProposerPercentageOfFees()
 	require.NoError(t, err)
@@ -55,6 +54,7 @@ func TestUtilityContext_ApplyBlock(t *testing.T) {
 	feesAndRewardsCollectedFloat.Mul(feesAndRewardsCollectedFloat, big.NewFloat(float64(proposerCutPercentage)))
 	feesAndRewardsCollectedFloat.Quo(feesAndRewardsCollectedFloat, big.NewFloat(100))
 	expectedProposerBalanceDifference, _ := feesAndRewardsCollectedFloat.Int(nil)
+
 	proposerAfterBalance, err := ctx.GetAccountAmount(addrBz)
 	require.NoError(t, err)
 
@@ -67,15 +67,18 @@ func TestUtilityContext_ApplyBlock(t *testing.T) {
 func TestUtilityContext_BeginBlock(t *testing.T) {
 	ctx := NewTestingUtilityContext(t, 0)
 	tx, _, _, _ := newTestingTransaction(t, ctx)
-	vals := getAllTestingValidators(t, ctx)
-	proposer := vals[0]
+
+	proposer := getFirstActor(t, ctx, typesUtil.ActorType_Validator)
+
 	txBz, err := tx.Bytes()
 	require.NoError(t, err)
+
 	addrBz, er := hex.DecodeString(proposer.GetAddress())
 	require.NoError(t, er)
+
 	er = ctx.GetPersistenceContext().SetProposalBlock("", addrBz, nil, [][]byte{txBz})
 	require.NoError(t, er)
-	// apply block
+
 	_, er = ctx.ApplyBlock()
 	require.NoError(t, er)
 
@@ -88,66 +91,30 @@ func TestUtilityContext_BeginBlock(t *testing.T) {
 	test_artifacts.CleanupTest(ctx)
 }
 
-func TestUtilityContext_BeginUnstakingMaxPausedActors(t *testing.T) {
-	for _, actorType := range actorTypes {
-		t.Run(fmt.Sprintf("%s.BeginUnstakingMaxPausedActors", actorType.String()), func(t *testing.T) {
-			ctx := NewTestingUtilityContext(t, 1)
-			actor := getFirstActor(t, ctx, actorType)
-
-			var err error
-			switch actorType {
-			case typesUtil.ActorType_App:
-				err = ctx.Context.SetParam(typesUtil.AppMaxPauseBlocksParamName, 0)
-			case typesUtil.ActorType_Validator:
-				err = ctx.Context.SetParam(typesUtil.ValidatorMaxPausedBlocksParamName, 0)
-			case typesUtil.ActorType_Fisherman:
-				err = ctx.Context.SetParam(typesUtil.FishermanMaxPauseBlocksParamName, 0)
-			case typesUtil.ActorType_ServiceNode:
-				err = ctx.Context.SetParam(typesUtil.ServiceNodeMaxPauseBlocksParamName, 0)
-			default:
-				t.Fatalf("unexpected actor type %s", actorType.String())
-			}
-			require.NoError(t, err)
-
-			addrBz, er := hex.DecodeString(actor.GetAddress())
-			require.NoError(t, er)
-
-			err = ctx.SetActorPauseHeight(actorType, addrBz, 0)
-			require.NoError(t, err)
-
-			err = ctx.BeginUnstakingMaxPaused()
-			require.NoError(t, err)
-
-			status, err := ctx.GetActorStatus(actorType, addrBz)
-			require.Equal(t, int32(typesUtil.StakeStatus_Unstaking), status, "incorrect status")
-
-			test_artifacts.CleanupTest(ctx)
-		})
-	}
-}
-
 func TestUtilityContext_EndBlock(t *testing.T) {
 	ctx := NewTestingUtilityContext(t, 0)
 	tx, _, _, _ := newTestingTransaction(t, ctx)
-	vals := getAllTestingValidators(t, ctx)
-	proposer := vals[0]
+
+	proposer := getFirstActor(t, ctx, typesUtil.ActorType_Validator)
 
 	txBz, err := tx.Bytes()
 	require.NoError(t, err)
+
 	addrBz, er := hex.DecodeString(proposer.GetAddress())
 	require.NoError(t, er)
+
 	proposerBeforeBalance, err := ctx.GetAccountAmount(addrBz)
 	require.NoError(t, err)
+
 	er = ctx.GetPersistenceContext().SetProposalBlock("", addrBz, nil, [][]byte{txBz})
 	require.NoError(t, er)
-	// apply block
+
 	_, er = ctx.ApplyBlock()
 	require.NoError(t, er)
-	// deliverTx logic verify
+
 	feeBig, err := ctx.GetMessageSendFee()
 	require.NoError(t, err)
 
-	// end-block logic verify
 	proposerCutPercentage, err := ctx.GetProposerPercentageOfFees()
 	require.NoError(t, err)
 
@@ -162,55 +129,4 @@ func TestUtilityContext_EndBlock(t *testing.T) {
 	require.Equal(t, expectedProposerBalanceDifference, proposerBalanceDifference)
 
 	test_artifacts.CleanupTest(ctx)
-}
-
-func TestUtilityContext_UnstakeValidatorsActorsThatAreReady(t *testing.T) {
-	for _, actorType := range actorTypes {
-		t.Run(fmt.Sprintf("%s.UnstakeValidatorsActorsThatAreReady", actorType.String()), func(t *testing.T) {
-			ctx := NewTestingUtilityContext(t, 1)
-
-			var poolName string
-			switch actorType {
-			case typesUtil.ActorType_App:
-				poolName = typesUtil.PoolNames_AppStakePool.String()
-			case typesUtil.ActorType_Validator:
-				poolName = typesUtil.PoolNames_ValidatorStakePool.String()
-			case typesUtil.ActorType_Fisherman:
-				poolName = typesUtil.PoolNames_FishermanStakePool.String()
-			case typesUtil.ActorType_ServiceNode:
-				poolName = typesUtil.PoolNames_ServiceNodeStakePool.String()
-			default:
-				t.Fatalf("unexpected actor type %s", actorType.String())
-			}
-			ctx.SetPoolAmount(poolName, big.NewInt(math.MaxInt64))
-
-			err := ctx.Context.SetParam(typesUtil.AppUnstakingBlocksParamName, 0)
-			require.NoError(t, err)
-
-			err = ctx.Context.SetParam(typesUtil.AppMaxPauseBlocksParamName, 0)
-			require.NoError(t, err)
-
-			actors := getAllTestingActors(t, ctx, actorType)
-			for _, actor := range actors {
-				// require.Equal(t, int32(typesUtil.StakedStatus), actor.GetStatus(), "wrong starting status")
-				addrBz, er := hex.DecodeString(actor.GetAddress())
-				require.NoError(t, er)
-				er = ctx.SetActorPauseHeight(actorType, addrBz, 1)
-				require.NoError(t, er)
-			}
-
-			err = ctx.UnstakeActorPausedBefore(2, actorType)
-			require.NoError(t, err)
-
-			err = ctx.UnstakeActorsThatAreReady()
-			require.NoError(t, err)
-
-			actors = getAllTestingActors(t, ctx, actorType)
-			require.NotEqual(t, actors[0].GetUnstakingHeight(), -1, "validators still exists after unstake that are ready() call")
-
-			// TODO: We need to better define what 'deleted' really is in the postgres world.
-			// We might not need to 'unstakeActorsThatAreReady' if we are already filtering by unstakingHeight
-			test_artifacts.CleanupTest(ctx)
-		})
-	}
 }

--- a/utility/test/module_test.go
+++ b/utility/test/module_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"encoding/hex"
 	"log"
-	"math/big"
 	"os"
 	"testing"
 
@@ -28,12 +27,13 @@ const (
 
 var (
 	defaultTestingChainsEdited = []string{"0002"}
-	defaultUnstaking           = int64(2017)
-	defaultSendAmount          = big.NewInt(10000)
-	defaultNonceString         = utilTypes.BigIntToString(defaults.DefaultAccountAmount)
-	defaultSendAmountString    = utilTypes.BigIntToString(defaultSendAmount)
-	testSchema                 = "test_schema"
-	testMessageSendType        = "MessageSend"
+
+	defaultUnstaking   = int64(2017)
+	defaultNonceString = utilTypes.BigIntToString(defaults.DefaultAccountAmount)
+
+	testNonce           = "defaultNonceString"
+	testSchema          = "test_schema"
+	testMessageSendType = "MessageSend"
 )
 
 var testPersistenceMod modules.PersistenceModule // initialized in TestMain

--- a/utility/test/transaction_test.go
+++ b/utility/test/transaction_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pokt-network/pocket/shared/crypto"
 	"github.com/pokt-network/pocket/utility"
 	typesUtil "github.com/pokt-network/pocket/utility/types"
+	utilTypes "github.com/pokt-network/pocket/utility/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -133,25 +134,26 @@ func TestUtilityContext_HandleMessage(t *testing.T) {
 	test_artifacts.CleanupTest(ctx)
 }
 
-func newTestingTransaction(t *testing.T, ctx utility.UtilityContext) (transaction *typesUtil.Transaction, startingAmount, amountSent *big.Int, signer crypto.PrivateKey) {
-	cdc := codec.GetCodec()
-	recipient := GetAllTestingAccounts(t, ctx)[2] // Using index 2 to prevent a collision with the first Validator who is the proposer in tests
+func newTestingTransaction(t *testing.T, ctx utility.UtilityContext) (transaction *typesUtil.Transaction, startingBalance, amountSent *big.Int, signer crypto.PrivateKey) {
+	amountSent = new(big.Int).Set(defaults.DefaultSendAmount)
+	startingBalance = new(big.Int).Set(defaults.DefaultAccountAmount)
 
-	signer, err := crypto.GeneratePrivateKey()
+	recipientAddr, err := crypto.GenerateAddress()
 	require.NoError(t, err)
 
-	startingAmount = defaults.DefaultAccountAmount
+	signer, err = crypto.GeneratePrivateKey()
+	require.NoError(t, err)
+
 	signerAddr := signer.Address()
-	require.NoError(t, ctx.SetAccountAmount(signerAddr, startingAmount))
-	amountSent = defaultSendAmount
-	addrBz, err := hex.DecodeString(recipient.GetAddress())
+	require.NoError(t, ctx.SetAccountAmount(signerAddr, startingBalance))
+
+	msg := NewTestingSendMessage(t, signerAddr, recipientAddr.Bytes(), utilTypes.BigIntToString(amountSent))
+	any, err := codec.GetCodec().ToAny(&msg)
 	require.NoError(t, err)
-	msg := NewTestingSendMessage(t, signerAddr, addrBz, defaultSendAmountString)
-	any, err := cdc.ToAny(&msg)
-	require.NoError(t, err)
+
 	transaction = &typesUtil.Transaction{
 		Msg:   any,
-		Nonce: defaultNonceString,
+		Nonce: testNonce,
 	}
 	require.NoError(t, transaction.Sign(signer))
 

--- a/utility/test/transaction_test.go
+++ b/utility/test/transaction_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	defaultSendAmount = big.NewInt(10000)
+)
+
 func TestUtilityContext_AnteHandleMessage(t *testing.T) {
 	ctx := NewTestingUtilityContext(t, 0)
 
@@ -135,7 +139,7 @@ func TestUtilityContext_HandleMessage(t *testing.T) {
 }
 
 func newTestingTransaction(t *testing.T, ctx utility.UtilityContext) (transaction *typesUtil.Transaction, startingBalance, amountSent *big.Int, signer crypto.PrivateKey) {
-	amountSent = new(big.Int).Set(defaults.DefaultSendAmount)
+	amountSent = new(big.Int).Set(defaultSendAmount)
 	startingBalance = new(big.Int).Set(defaults.DefaultAccountAmount)
 
 	recipientAddr, err := crypto.GenerateAddress()


### PR DESCRIPTION
## Description

Fix a flaky unit test in the utility module and address a bit of tech debt in parallel.

## Issue

Fixes #373

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

**Root cause of bug:**
- In `newTestingTransaction`, always make the recipient a random address. This avoids the situation where the `proposer` and the `recipient` are the same (unlike but possible) resulting in the balance being increment in two different ways.

**Code cleanup:**
- Change order of params in `getActorByAddr`
- Avoid a few places with redundant byte <> string conversions
- Move tests from `block_test.go` that belong in `actor_test.go`
- Use more semantic variable naming where appropriate
- Use the `getFirstActor` helper test function in a few places
- Remove incorrect comments


## Testing

- [x] `for i in {1..100}; do go test -timeout 2s -count=1 -run ^TestUtilityContext_ApplyBlock$ github.com/pokt-network/pocket/utility/test; done; `
- [x] `make develop_test`
- [x] `make test_utility`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
