### PR TITLE
[Quick ci change] avoid github action protoc download throttling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: install cli dependencies
         run: make install_cli_deps
       - name: generate protobufs, RPC server, RPC client and mocks


### PR DESCRIPTION
## Description

Our repo utilizes shared github runners which are prone to bottleneck on interaction with other services due to shared IPs/subnets. This time we hit a limit on downloads per IP on github's own artifact store, but this can be bypassed when the token is provided. 