### PR TITLE
[Consensus] Switch RainTree broadcast to star-pattern broadcast

### DIFF
--- a/consensus/block.go
+++ b/consensus/block.go
@@ -13,6 +13,7 @@ func (m *consensusModule) commitBlock(block *typesCons.Block) error {
 		return err
 	}
 	m.nodeLog(typesCons.CommittingBlock(m.height, len(block.Transactions)))
+	// TODO: Broadcast block to the entire network (RainTree + random gossip)
 
 	// Release the context
 	if err := m.utilityContext.Release(); err != nil {

--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.14] - 2022-12-15
+
+- Rename `sendToNode` to `sendToLeader`
+- Rename `broadcastToNodes` to `broadcastToValidators`
+- Change HotPOKT broadcast from `RainTree` to `start pattern`
 
 ## [0.0.0.13] - 2022-12-14
 

--- a/consensus/hotstuff_leader.go
+++ b/consensus/hotstuff_leader.go
@@ -81,7 +81,7 @@ func (handler *HotstuffLeaderMessageHandler) HandleNewRoundMessage(m *consensusM
 		m.paceMaker.InterruptRound()
 		return
 	}
-	m.broadcastToNodes(prepareProposeMessage)
+	m.broadcastToValidators(prepareProposeMessage)
 
 	// Leader also acts like a replica
 	prepareVoteMessage, err := CreateVoteMessage(m.height, m.round, Prepare, m.block, m.privateKey)
@@ -89,7 +89,7 @@ func (handler *HotstuffLeaderMessageHandler) HandleNewRoundMessage(m *consensusM
 		m.nodeLogError(typesCons.ErrCreateVoteMessage(Prepare).Error(), err)
 		return
 	}
-	m.sendToNode(prepareVoteMessage)
+	m.sendToLeader(prepareVoteMessage)
 }
 
 /*** PreCommit Step ***/
@@ -125,7 +125,7 @@ func (handler *HotstuffLeaderMessageHandler) HandlePrepareMessage(m *consensusMo
 		m.paceMaker.InterruptRound()
 		return
 	}
-	m.broadcastToNodes(preCommitProposeMessage)
+	m.broadcastToValidators(preCommitProposeMessage)
 
 	// Leader also acts like a replica
 	precommitVoteMessage, err := CreateVoteMessage(m.height, m.round, PreCommit, m.block, m.privateKey)
@@ -133,7 +133,7 @@ func (handler *HotstuffLeaderMessageHandler) HandlePrepareMessage(m *consensusMo
 		m.nodeLogError(typesCons.ErrCreateVoteMessage(PreCommit).Error(), err)
 		return
 	}
-	m.sendToNode(precommitVoteMessage)
+	m.sendToLeader(precommitVoteMessage)
 }
 
 /*** Commit Step ***/
@@ -169,7 +169,7 @@ func (handler *HotstuffLeaderMessageHandler) HandlePrecommitMessage(m *consensus
 		m.paceMaker.InterruptRound()
 		return
 	}
-	m.broadcastToNodes(commitProposeMessage)
+	m.broadcastToValidators(commitProposeMessage)
 
 	// Leader also acts like a replica
 	commitVoteMessage, err := CreateVoteMessage(m.height, m.round, Commit, m.block, m.privateKey)
@@ -177,7 +177,7 @@ func (handler *HotstuffLeaderMessageHandler) HandlePrecommitMessage(m *consensus
 		m.nodeLogError(typesCons.ErrCreateVoteMessage(Commit).Error(), err)
 		return
 	}
-	m.sendToNode(commitVoteMessage)
+	m.sendToLeader(commitVoteMessage)
 }
 
 /*** Decide Step ***/
@@ -212,7 +212,7 @@ func (handler *HotstuffLeaderMessageHandler) HandleCommitMessage(m *consensusMod
 		m.paceMaker.InterruptRound()
 		return
 	}
-	m.broadcastToNodes(decideProposeMessage)
+	m.broadcastToValidators(decideProposeMessage)
 
 	if err := m.commitBlock(m.block); err != nil {
 		m.nodeLogError(typesCons.ErrCommitBlock.Error(), err)

--- a/consensus/hotstuff_replica.go
+++ b/consensus/hotstuff_replica.go
@@ -73,7 +73,7 @@ func (handler *HotstuffReplicaMessageHandler) HandlePrepareMessage(m *consensusM
 		m.nodeLogError(typesCons.ErrCreateVoteMessage(Prepare).Error(), err)
 		return // Not interrupting the round because liveness could continue with one failed vote
 	}
-	m.sendToNode(prepareVoteMessage)
+	m.sendToLeader(prepareVoteMessage)
 }
 
 /*** PreCommit Step ***/
@@ -102,7 +102,7 @@ func (handler *HotstuffReplicaMessageHandler) HandlePrecommitMessage(m *consensu
 		m.nodeLogError(typesCons.ErrCreateVoteMessage(PreCommit).Error(), err)
 		return // Not interrupting the round because liveness could continue with one failed vote
 	}
-	m.sendToNode(preCommitVoteMessage)
+	m.sendToLeader(preCommitVoteMessage)
 }
 
 /*** Commit Step ***/
@@ -131,7 +131,7 @@ func (handler *HotstuffReplicaMessageHandler) HandleCommitMessage(m *consensusMo
 		m.nodeLogError(typesCons.ErrCreateVoteMessage(Commit).Error(), err)
 		return // Not interrupting the round because liveness could continue with one failed vote
 	}
-	m.sendToNode(commitVoteMessage)
+	m.sendToLeader(commitVoteMessage)
 }
 
 /*** Decide Step ***/

--- a/consensus/module.go
+++ b/consensus/module.go
@@ -56,11 +56,11 @@ type consensusModule struct {
 	// Leader Election
 	leaderId       *typesCons.NodeId
 	nodeId         typesCons.NodeId
-	valAddrToIdMap typesCons.ValAddrToIdMap // TODO: This needs to be updated every time the ValMap is modified
-	idToValAddrMap typesCons.IdToValAddrMap // TODO: This needs to be updated every time the ValMap is modified
+	valAddrToIdMap typesCons.ValAddrToIdMap // TODO: This needs to be updated on every height
+	idToValAddrMap typesCons.IdToValAddrMap // TODO: This needs to be updated on every height
 
 	// Consensus State
-	validatorMap typesCons.ValidatorMap
+	validatorMap typesCons.ValidatorMap // TODO: This needs to be updated on every height
 
 	// Module Dependencies
 	// TODO(#283): Improve how `utilityContext` is managed

--- a/consensus/pacemaker.go
+++ b/consensus/pacemaker.go
@@ -254,7 +254,7 @@ func (p *paceMaker) startNextView(qc *typesCons.QuorumCertificate, forceNextView
 	}
 
 	p.RestartTimer()
-	p.consensusMod.broadcastToNodes(hotstuffMessage)
+	p.consensusMod.broadcastToValidators(hotstuffMessage)
 }
 
 // TODO(olshansky): Increase timeout using exponential backoff.


### PR DESCRIPTION
## Description

tl;dr Stabilize LocalNet

After #374 was merged, LocalNet was not as stable as before. One of the reasons for this is because we were using `P2P.Broadcast()`, which uses `RainTree` by default, whereas `HotPOKT` expects a star-like pattern.

Followup work / documentation may involve exposing or documenting the difference between the following:
- `BroadcastToValidators` - Direct O(N) send from a `leader` to all `validator` replicas used by `HotPOKT`
- `BroadcastToStakedActors` - O(log3N) broadcast using `RainTree` from an originator to all staked nodes
- `RandomBroadcast` - Random gossip to all nodes (staked or not), including full nodes

## Issue

Bugfix

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Rename `sendToNode` to `sendToLeader`
- Rename `broadcastToNodes` to `broadcastToValidators`
- Change HotPOKT broadcast from `RainTree` to `start pattern`

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
