### PR TITLE
[Docs] Add LocalNet issues and solutions to FAQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,11 @@ develop_test: docker_check ## Run all of the make commands necessary to develop 
 
 .PHONY: client_start
 client_start: docker_check ## Run a client daemon which is only used for debugging purposes
-	docker-compose -f build/deployments/docker-compose.yaml up -d client --build
+	docker-compose -f build/deployments/docker-compose.yaml up -d client
+
+.PHONY: rebuild_client_start
+client_start: docker_check ## Rebuild and run a client daemon which is only used for debugging purposes
+	docker-compose -f build/deployments/docker-compose.yaml up -d --build client
 
 .PHONY: client_connect
 client_connect: docker_check ## Connect to the running client debugging daemon

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -4,7 +4,59 @@ A list of common issues & resolutions shared by the V1 contributors
 
 ## Avoid redundant files from iCloud backup
 
-* **Issue**: when working on MacOS with iCloud backup turned on, redundant files could be generated in GitHub projects. (e.g. `file.go` and `file 2.go`) Details can be found here in [this link](https://stackoverflow.com/a/62387243). 
+* **Issue**: when working on MacOS with iCloud backup turned on, redundant files could be generated in GitHub projects. (e.g. `file.go` and `file 2.go`) Details can be found here in [this link](https://stackoverflow.com/a/62387243).
 * **Solution**: adding `.nosync` as suffix to the workspace folder, e.g. `pocket.nosync`. Alternative, working in a folder that iCloud doesn't touch also works.
+
+## Unable to start LocalNet - permission denied
+
+* **Issue**: when trying to run `make compose_and_watch` on an operating system with SELinux, the command gives the error:
+```
+Recreating node2.consensus ... done
+Recreating node4.consensus ... done
+Recreating node1.consensus ... done
+Recreating node3.consensus ... done
+Attaching to node3.consensus, node1.consensus, node2.consensus, node4.consensus
+node2.consensus    | /bin/sh: can't open 'build/scripts/watch.sh': Permission denied
+node1.consensus    | /bin/sh: can't open 'build/scripts/watch.sh': Permission denied
+node3.consensus    | /bin/sh: can't open 'build/scripts/watch.sh': Permission denied
+node1.consensus exited with code 2
+node4.consensus    | /bin/sh: can't open 'build/scripts/watch.sh': Permission denied
+node2.consensus exited with code 2
+node3.consensus exited with code 2
+node4.consensus exited with code 2
+```
+* **Solution**: A temporary fix would be to run
+```
+$ su -c "setenforce 0"
+```
+Whereas a permenant approach would be to allow the docker container access to the local repository
+```
+$ cd pocket
+$ sudo chcon -Rt svirt_sandbox_file_t ./
+```
+
+See [this stackoverflow post](https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker) for more details
+
+## Unable to create a LocalNet client
+
+* **Issue**: When running `make client_start` you get the error message
+```
+ERROR: No such service: --build
+make: *** [Makefile:125: client_start] Error 1
+```
+
+* **Solution**: open `Makefile` and edit the following block of code
+```
+.PHONY: client_start
+client_start: docker_check ## Run a client daemon which is only used for debugging purposes
+    docker-compose -f build/deployments/docker-compose.yaml up -d client --build
+```
+
+Remove the `--build` so the lines look like:
+```
+.PHONY: client_start
+client_start: docker_check ## Run a client daemon which is only used for debugging purposes
+    docker-compose -f build/deployments/docker-compose.yaml up -d client
+```
 
 _NOTE: Consider turning of the `gofmt` in your IDE to prevent unexpected formatting_

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -35,7 +35,9 @@ node4.consensus exited with code 2
 su -c "setenforce 0"
 ```
 
+
 Whereas a permenant approach would be to allow the docker container access to the local repository
+
 
 ```bash
 sudo chcon -Rt svirt_sandbox_file_t ./pocket

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -7,6 +7,8 @@ A list of common issues & resolutions shared by the V1 contributors
 * **Issue**: when working on MacOS with iCloud backup turned on, redundant files could be generated in GitHub projects. (e.g. `file.go` and `file 2.go`) Details can be found here in [this link](https://stackoverflow.com/a/62387243).
 * **Solution**: adding `.nosync` as suffix to the workspace folder, e.g. `pocket.nosync`. Alternative, working in a folder that iCloud doesn't touch also works.
 
+_NOTE: Consider turning of the `gofmt` in your IDE to prevent unexpected formatting_
+
 ## Unable to start LocalNet - permission denied
 
 * **Issue**: when trying to run `make compose_and_watch` on an operating system with SELinux, the command gives the error:
@@ -64,5 +66,3 @@ Remove the `--build` so the lines look like:
 client_start: docker_check ## Run a client daemon which is only used for debugging purposes
     docker-compose -f build/deployments/docker-compose.yaml up -d client
 ```
-
-_NOTE: Consider turning of the `gofmt` in your IDE to prevent unexpected formatting_

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -60,9 +60,11 @@ client_start: docker_check ## Run a client daemon which is only used for debuggi
     docker-compose -f build/deployments/docker-compose.yaml up -d client --build
 ```
 
-Remove the `--build` so the lines look like:
+Move the `--build` profile so that it is before the `client` service, making the lines look like:
 ```make
 .PHONY: client_start
 client_start: docker_check ## Run a client daemon which is only used for debugging purposes
-    docker-compose -f build/deployments/docker-compose.yaml up -d client
+    docker-compose -f build/deployments/docker-compose.yaml up -d --build client
 ```
+
+For more information on this refer to the [docker documentation](https://docs.docker.com/compose/profiles/)

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -35,9 +35,7 @@ node4.consensus exited with code 2
 su -c "setenforce 0"
 ```
 
-
 Whereas a permenant approach would be to allow the docker container access to the local repository
-
 
 ```bash
 sudo chcon -Rt svirt_sandbox_file_t ./pocket

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -42,29 +42,3 @@ sudo chcon -Rt svirt_sandbox_file_t ./pocket
 ```
 
 See [this stackoverflow post](https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker) for more details.
-
-## Unable to create a LocalNet client
-
-* **Issue**: When running `make client_start` you get the error message:
-
-```
-ERROR: No such service: --build
-make: *** [Makefile:125: client_start] Error 1
-```
-
-* **Solution**: open `Makefile` and edit the following block of code
-
-```make
-.PHONY: client_start
-client_start: docker_check ## Run a client daemon which is only used for debugging purposes
-    docker-compose -f build/deployments/docker-compose.yaml up -d client --build
-```
-
-Move the `--build` flag so that it is before the `client` service, making the lines look like:
-```make
-.PHONY: client_start
-client_start: docker_check ## Run a client daemon which is only used for debugging purposes
-    docker-compose -f build/deployments/docker-compose.yaml up -d --build client
-```
-
-For more information on this refer to the [docker documentation](https://docs.docker.com/engine/reference/commandline/compose_up/)

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -10,6 +10,7 @@ A list of common issues & resolutions shared by the V1 contributors
 ## Unable to start LocalNet - permission denied
 
 * **Issue**: when trying to run `make compose_and_watch` on an operating system with SELinux, the command gives the error:
+
 ```
 Recreating node2.consensus ... done
 Recreating node4.consensus ... done
@@ -25,35 +26,40 @@ node2.consensus exited with code 2
 node3.consensus exited with code 2
 node4.consensus exited with code 2
 ```
+
 * **Solution**: A temporary fix would be to run
-```
-$ su -c "setenforce 0"
-```
-Whereas a permenant approach would be to allow the docker container access to the local repository
-```
-$ cd pocket
-$ sudo chcon -Rt svirt_sandbox_file_t ./
+
+```bash
+su -c "setenforce 0"
 ```
 
-See [this stackoverflow post](https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker) for more details
+Whereas a permenant approach would be to allow the docker container access to the local repository
+
+```bash
+sudo chcon -Rt svirt_sandbox_file_t ./pocket
+```
+
+See [this stackoverflow post](https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker) for more details.
 
 ## Unable to create a LocalNet client
 
-* **Issue**: When running `make client_start` you get the error message
+* **Issue**: When running `make client_start` you get the error message:
+
 ```
 ERROR: No such service: --build
 make: *** [Makefile:125: client_start] Error 1
 ```
 
 * **Solution**: open `Makefile` and edit the following block of code
-```
+
+```make
 .PHONY: client_start
 client_start: docker_check ## Run a client daemon which is only used for debugging purposes
     docker-compose -f build/deployments/docker-compose.yaml up -d client --build
 ```
 
 Remove the `--build` so the lines look like:
-```
+```make
 .PHONY: client_start
 client_start: docker_check ## Run a client daemon which is only used for debugging purposes
     docker-compose -f build/deployments/docker-compose.yaml up -d client

--- a/docs/development/FAQ.md
+++ b/docs/development/FAQ.md
@@ -60,11 +60,11 @@ client_start: docker_check ## Run a client daemon which is only used for debuggi
     docker-compose -f build/deployments/docker-compose.yaml up -d client --build
 ```
 
-Move the `--build` profile so that it is before the `client` service, making the lines look like:
+Move the `--build` flag so that it is before the `client` service, making the lines look like:
 ```make
 .PHONY: client_start
 client_start: docker_check ## Run a client daemon which is only used for debugging purposes
     docker-compose -f build/deployments/docker-compose.yaml up -d --build client
 ```
 
-For more information on this refer to the [docker documentation](https://docs.docker.com/compose/profiles/)
+For more information on this refer to the [docker documentation](https://docs.docker.com/engine/reference/commandline/compose_up/)


### PR DESCRIPTION
## Description

Fix errors with the `Makefile` by removing the `--build` flag from the incorrect position in the `client_start` command, and add the `rebuild_client_start` command as well.

Add a description of an issue relating to starting the LocalNet with SELinux and its solution to `docs/development/FAQ.md`. This will be useful when `make compose_and_watch` throw errors, these have also been included in the file..

## Issue

No issue documentation update

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Add issue and solution to FAQ for SELinux blocking the docker container from accessing local files to start the LocalNet
- Remove the `--build` flag from the `client_start` command in the `Makefile` and add the `rebuild_client_start` command with the `--build` flag in the correct position

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [x] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
