### PR TITLE
[Docs] Build Makefile for p1 CLI documentation

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,6 +6,7 @@ Please note that this repository is under very active development and breaking c
   - [LFG - Development](#lfg---development)
     - [Install Dependencies](#install-dependencies)
     - [Prepare Local Environment](#prepare-local-environment)
+    - [Pocket Network CLI](#pocket-network-cli)
     - [View Available Commands](#view-available-commands)
     - [Running Unit Tests](#running-unit-tests)
     - [Running LocalNet](#running-localnet)
@@ -73,6 +74,29 @@ chmod +x .git/hooks/pre-commit
 
 _Please note that the Github workflow will still prevent this from merging
 unless the CHANGELOG is updated._
+
+### Pocket Network CLI
+
+Pocket provides a CLI for interacting with Pocket Core. The CLI is meant to be an user but also a machine friendly way for interacting with Pocket Network.
+
+The commands available are listed [here](../../app/client/cli/doc/commands/client.md).
+
+In order to build the CLI:
+
+1. Generate local files
+
+```bash
+make develop_start
+```
+
+2. Build the CLI
+
+```bash
+make build
+```
+
+The cli binary will be available at `bin/p1`.
+
 
 ### View Available Commands
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -7,6 +7,7 @@ Please note that this repository is under very active development and breaking c
     - [Install Dependencies](#install-dependencies)
     - [Prepare Local Environment](#prepare-local-environment)
     - [Pocket Network CLI](#pocket-network-cli)
+    - [Swagger UI](#swagger-ui)
     - [View Available Commands](#view-available-commands)
     - [Running Unit Tests](#running-unit-tests)
     - [Running LocalNet](#running-localnet)
@@ -77,9 +78,7 @@ unless the CHANGELOG is updated._
 
 ### Pocket Network CLI
 
-Pocket provides a CLI for interacting with Pocket Core. The CLI is meant to be an user but also a machine friendly way for interacting with Pocket Network.
-
-The commands available are listed [here](../../app/client/cli/doc/commands/client.md).
+The Pocket node provides a CLI for interacting with Pocket RPC Server. The CLI can be used for both read & write operations by both users and to aid in automation.
 
 In order to build the CLI:
 
@@ -89,14 +88,25 @@ In order to build the CLI:
 make develop_start
 ```
 
-2. Build the CLI
+2. Build the CLI binary
 
 ```bash
 make build
 ```
 
-The cli binary will be available at `bin/p1`.
+The cli binary will be available at `bin/p1` and can be used instead of `go run app/client/*.go`
 
+The commands available are listed [here](../../rpc/doc/README.md) or acessible via `bin/p1 --help`
+
+### Swagger UI
+
+Swagger UI is available to help during the development process.
+
+In order to spin an local instance of it with the API definition for the Pocket Network Node RPC interface automatically pre-loaded you can run:
+
+```bash
+make swagger-ui
+```
 
 ### View Available Commands
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -102,7 +102,7 @@ The commands available are listed [here](../../rpc/doc/README.md) or acessible v
 
 Swagger UI is available to help during the development process.
 
-In order to spin an local instance of it with the API definition for the Pocket Network Node RPC interface automatically pre-loaded you can run:
+In order to spin a local instance of it with the API definition for the Pocket Network Node RPC interface automatically pre-loaded you can run:
 
 ```bash
 make swagger-ui

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -78,7 +78,7 @@ unless the CHANGELOG is updated._
 
 ### Pocket Network CLI
 
-The Pocket node provides a CLI for interacting with Pocket RPC Server. The CLI can be used for both read & write operations by both users and to aid in automation.
+The Pocket node provides a CLI for interacting with Pocket RPC Server. The CLI can be used for both read & write operations by users and to aid in automation.
 
 In order to build the CLI:
 


### PR DESCRIPTION
## Description

This adds documentation mentioning the p1 binary (Pocket CLI) and how to build it utilizing the newly created Makefile targets.

## Issue

Fixes #366

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Created a  `Pocket Network CLI` section in the development README.md

## Testing

- [ ] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [x] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [x] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
