### PR TITLE
Fix target for `rebuild_client_start`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ client_start: docker_check ## Run a client daemon which is only used for debuggi
 	docker-compose -f build/deployments/docker-compose.yaml up -d client
 
 .PHONY: rebuild_client_start
-client_start: docker_check ## Rebuild and run a client daemon which is only used for debugging purposes
+rebuild_client_start: docker_check ## Rebuild and run a client daemon which is only used for debugging purposes
 	docker-compose -f build/deployments/docker-compose.yaml up -d --build client
 
 .PHONY: client_connect


### PR DESCRIPTION
Quick fix for #417 which was overriding the target for `client_start` rather than creating a new one for `rebuild_client_start`