### PR TITLE
[Docs] tidy learning readme

### DIFF
--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -133,7 +133,6 @@ This is a general set of technical links and recommended reading our team has fo
 
 - [Pocket YouTube Channel](https://www.youtube.com/c/PocketNetwork/videos)
   - Contains everything from Infracon presentations, to contributor hour calls, etc...
-  -
 
 ### Consensus
 


### PR DESCRIPTION
Removes an empty bullet point line.

## Description

This change just removes a blank line following a bullet point that I noticed while reading.

## Issue

No related issue.

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Deleted a stray bullet point at the end of an unordered list.

## Testing

- [ ] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`


## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
