### PR TITLE
[Tooling] changelog date verification: compare against last relevant commit

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+#
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+BRANCH_CHANGED_FILES=($(git diff --name-only main..HEAD))
+
+# Initialise arrays and script wide variables
+IGNORE_DIRS=(".github" ".githooks" "docs" "bin")
+MODULES_EDITED=() # Modules are considered top-level directories directly under root
+MODULES_MISSING_CHANGELOG=()
+CHANGELOG_FILES=() # Full paths to CHANGELOG.md files
+CHANGELOG_ERRORS_FOUND=0
+
+# Loop through staged files
+for file in "${BRANCH_CHANGED_FILES[@]}"
+do
+    # Check the files contained in modules/top-level subdirs only
+    if [[ "${file}" =~ /+ ]]
+    then
+        module="$(echo "${file}" | sed 's/\/.*//')"
+        # Only add to modules list if not already present
+        if [[ ! "${MODULES_EDITED[*]}" =~ ${module} ]]
+        then
+            # Skip ignored modules if present
+            [[ ! "${IGNORE_DIRS[*]}" =~ ${module} ]] && MODULES_EDITED+=("${module}")
+        fi
+    # If not a subdir but root level CHANGELOG.md
+    elif [[ "${file}" == 'CHANGELOG.md' ]]
+    then
+        CHANGELOG_FILES+=("${file}") # Validate root changelog
+    fi
+done
+
+# Check that for each module edited the CHANGELOG.md file
+# was included in the commit
+if [[ "${#MODULES_EDITED[@]}" != 0 ]]
+then
+    # Loop through edited modules checking for CHANGELOG.md
+    for module in "${MODULES_EDITED[@]}"
+    do
+        MODULE_CHANGELOG_INCLUDED=0
+        for file in "${BRANCH_CHANGED_FILES[@]}"
+        do
+            # If any files under /root/{module}/* were edited, make
+            # sure that a CHANGELOG.md file was found and save the
+            # path to verify it has been updated
+            if [[ "${file}" =~ "${module}"/* ]]
+            then
+                # If the file's path string contains CHANGELOG.md add the
+                # path to the CHANGELOG_FILES array to be verified.
+                # This RegEx check accounts for CHANGELOG location
+                # inconsistencies: module root or doc/docs subdir
+                if [[ "${file}" =~ CHANGELOG.md ]]
+                then
+                    CHANGELOG_FILES+=("${file}")
+                    MODULE_CHANGELOG_INCLUDED=1
+                fi
+            fi
+        done
+        # Add modules missing CHANGELOG.md to array
+        if [[ "${MODULE_CHANGELOG_INCLUDED}" == 0 ]]
+        then
+            MODULES_MISSING_CHANGELOG+=("${module}")
+        fi
+        MODULE_CHANGELOG_INCLUDED=0
+    done
+fi
+
+# Print error messages and prepare exit for modules missing changelogs
+if [[ "${#MODULES_MISSING_CHANGELOG[@]}" != 0 ]]
+then
+    for module in "${MODULES_MISSING_CHANGELOG[@]}"
+    do
+        printf 'Missing changelog in module: %s/\n\n' "${module}" >&2
+        CHANGELOG_ERRORS_FOUND=1
+	done
+fi
+
+# Check version numbers and dates in changelogs provided
+for log in "${CHANGELOG_FILES[@]}"
+do
+    # sed using BRE expression for portability
+    head_versions=($(sed -n 's/^.*\(\[[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\]\) - \([0-9][0-9]*-[0-9][0-9]*-[0-9][0-9]*\).*$/\1 \2/p' "${log}" | head -n2))
+    # Get latest and previous versions and strip any leading 0s
+    # and check the latest version is greater than the previous
+    latest_version=$(($(echo "${head_versions[0]:1:-1}" | sed 's/\.//g' | sed 's/^0*//')+0))
+    previous_version=$(($(echo "${head_versions[2]:1:-1}" | sed 's/\.//g' | sed 's/^0*//')+0))
+    if [[ "${latest_version}" -le "${previous_version}" ]]
+    then
+        printf 'Latest version in %s is incorrect.\nLatest: %s, Previous: %s\n\n' "${log}" "${head_versions[0]}" "${head_versions[2]}" >&2
+        CHANGELOG_ERRORS_FOUND=1
+    fi
+    # compare date in string format YY-mm-dd
+    latest_changelog_date="${head_versions[1]}"
+
+    # get current changelog's module path
+    module="$(echo "${log}" | sed 's/\/.*//')"
+    # consider files changed since branching off main
+    # filter for files relevant to current module
+    changed_module_files=$(git diff --name-only main..HEAD | grep -e "^$module" )
+    # sort commits affecting module files by date and take most recent
+    latest_module_commit_date=$(sort -r <(echo "$changed_module_files" | xargs -I {} git --no-pager log -1 --format=%cs {}) | head -n 1)
+
+
+    if [[ "${latest_changelog_date}" != "${latest_module_commit_date}" ]]
+    then
+        printf 'Latest date in %s is incorrect.\nLatest: %s, Current: %s\n\n' "${log}" "${head_versions[1]}" "${latest_module_commit_date}" >&2
+        CHANGELOG_ERRORS_FOUND=1
+    fi
+done
+
+# Exit with error code 1 after all error messages have been
+# printed to stderr. If no errors detected exit with code 0
+if [[ "${CHANGELOG_ERRORS_FOUND}" == 1 ]]
+then
+    printf 'Changelog verification failed. See error messages for more detail.\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/.github/workflows/changelog-verify.yml
+++ b/.github/workflows/changelog-verify.yml
@@ -39,4 +39,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Verify changelogs
-        run: bash ./.githooks/pre-commit ${{needs.changedfiles.outputs.all}}
+        run: bash ./.githooks/pre-push ${{needs.changedfiles.outputs.all}}


### PR DESCRIPTION
## Description

Duplicates and modifies the existing pre-commit hook to create a pre-push hook. This pre-push hook compares the CHANGELOG dates against the date of the most recent commit which affects the respective CHANGELOG's module.


## Issue

Fixes #456

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [x] Other: developer experience

## List of changes

- Derive pre-push hook from existing pre-commit which compares CHANGELOG version dates against the date of the last commit which affects the respective module, instead of the current date.
- Swap new pre-push hook out for pre-commit in changelog verification GitHub actions job.

## Testing

- [ ] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`


## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
