### PR TITLE
[TOOLING] Fix changelog verification for worklow to extract current date

### DIFF
--- a/.githooks/pre-receive
+++ b/.githooks/pre-receive
@@ -96,7 +96,7 @@ do
     module="$(echo "${log}" | sed 's/\/.*//')"
     # consider files changed since branching off main
     # filter for files relevant to current module
-    changed_module_files=$(git diff --name-only main..HEAD | grep -e "^$module" )
+    changed_module_files=($( printf '%s\n' "${BRANCH_CHANGED_FILES[@]}" | grep "${module}" ))
     # sort commits affecting module files by date and take most recent
     latest_module_commit_date=$(sort -r <(echo "$changed_module_files" | xargs -I {} git --no-pager log -1 --format=%cs {}) | head -n 1)
 


### PR DESCRIPTION
## Description

Quick fix to remove `changed_module_files=$(git diff --name-only main..HEAD | grep -e "^$module" )` which the github workflow has issues with and replace it with `changed_module_files=($( printf '%s\n' "${BRANCH_CHANGED_FILES[@]}" | grep "${module}" ))` so as to remove the need for the awkward git command.

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Remove the `git diff --name-only main..HEAD` command with a bash alternative

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
