### PR TITLE
Fix: unit tests in consensus, p2p and persistence modules

### DIFF
--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.23] - 2023-01-29
+
+- Fix `TestHotstuff4Nodes1BlockHappyPath` misplacement of actual and expected values in `require.Equal`
+
 ## [0.0.0.22] - 2023-01-25
 
 - Add a note on consensus test related workaround related to #462

--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.23] - 2023-01-29
+## [0.0.0.23] - 2023-01-30
 
 - Fix `TestHotstuff4Nodes1BlockHappyPath` misplacement of actual and expected values in `require.Equal`
 

--- a/consensus/e2e_tests/hotstuff_test.go
+++ b/consensus/e2e_tests/hotstuff_test.go
@@ -156,7 +156,7 @@ func TestHotstuff4Nodes1BlockHappyPath(t *testing.T) {
 					Round:  0,
 				},
 				nodeState)
-			require.Equal(t, nodeState.LeaderId, typesCons.NodeId(0), "Leader should be empty")
+			require.Equal(t, typesCons.NodeId(0), nodeState.LeaderId, "Leader should be empty")
 			continue
 		}
 		assertNodeConsensusView(t, pocketId,
@@ -186,7 +186,7 @@ func TestHotstuff4Nodes1BlockHappyPath(t *testing.T) {
 				Round:  0,
 			},
 			nodeState)
-		require.Equal(t, nodeState.LeaderId, typesCons.NodeId(0), "Leader should be empty")
+		require.Equal(t, typesCons.NodeId(0), nodeState.LeaderId, "Leader should be empty")
 	}
 }
 

--- a/p2p/CHANGELOG.md
+++ b/p2p/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.21] - 2023-01-29
+## [0.0.0.21] - 2023-01-30
 
 - Updated `TestRainTreeAddrBookUtilsHandleUpdate` and `testRainTreeMessageTargets` to correct incorrect expected and actual value placements.
 

--- a/p2p/CHANGELOG.md
+++ b/p2p/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.21] - 2023-01-29
+
+- Updated `TestRainTreeAddrBookUtilsHandleUpdate` and `testRainTreeMessageTargets` to correct incorrect expected and actual value placements.
+
 ## [0.0.0.20] - 2023-01-20
 
 - Updated `P2PConfig#IsEmptyConnectionType` bool to `P2PConfig#ConnectionType` enum

--- a/p2p/raintree/peers_manager_test.go
+++ b/p2p/raintree/peers_manager_test.go
@@ -83,9 +83,9 @@ func TestRainTreeAddrBookUtilsHandleUpdate(t *testing.T) {
 
 			peersManagerStateView := network.peersManager.getNetworkView()
 
-			require.Equal(t, len(peersManagerStateView.addrList), n)
-			require.Equal(t, len(peersManagerStateView.addrBookMap), n)
-			require.Equal(t, int(peersManagerStateView.maxNumLevels), testCase.numExpectedLevels)
+			require.Equal(t, n, len(peersManagerStateView.addrList))
+			require.Equal(t, n, len(peersManagerStateView.addrBookMap))
+			require.Equal(t, testCase.numExpectedLevels, int(peersManagerStateView.maxNumLevels))
 		})
 	}
 }
@@ -228,10 +228,10 @@ func testRainTreeMessageTargets(t *testing.T, expectedMsgProp *ExpectedRainTreeM
 		actualTargets := network.getTargetsAtLevel(uint32(target.level))
 
 		require.True(t, shouldSendToTarget(actualTargets[0]))
-		require.Equal(t, actualTargets[0].address, cryptoPocket.Address(target.left))
+		require.Equal(t, cryptoPocket.Address(target.left), actualTargets[0].address)
 
 		require.True(t, shouldSendToTarget(actualTargets[1]))
-		require.Equal(t, actualTargets[1].address, cryptoPocket.Address(target.right))
+		require.Equal(t, cryptoPocket.Address(target.right), actualTargets[1].address)
 	}
 }
 

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.28] - 2023-01-29
+
+- Fix unit tests - `TestGetAppPauseHeightIfExists`, `TestGetAppOutputAddress`, `TestGetFishermanStatus`, `TestGetFishermanPauseHeightIfExists`, `TestGetFishermanOutputAddress`, `TestPersistenceContextParallelReadWrite`, `TestGetServiceNodePauseHeightIfExists`, `TestGetServiceNodeOutputAddress`, `fuzzSingleProtocolActor`, `TestGetValidatorPauseHeightIfExists`, and `TestGetValidatorOutputAddress` for misplaced expected and actual values in `require.Equal`.
+
 ## [0.0.0.27] - 2023-01-27
 
 - Add logic for `updateParamsTree()` and `updateFlagsTree()` functions when updating merkle root hash

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.28] - 2023-01-29
+## [0.0.0.28] - 2023-01-30
 
 - Fix unit tests - `TestGetAppPauseHeightIfExists`, `TestGetAppOutputAddress`, `TestGetFishermanStatus`, `TestGetFishermanPauseHeightIfExists`, `TestGetFishermanOutputAddress`, `TestPersistenceContextParallelReadWrite`, `TestGetServiceNodePauseHeightIfExists`, `TestGetServiceNodeOutputAddress`, `fuzzSingleProtocolActor`, `TestGetValidatorPauseHeightIfExists`, and `TestGetValidatorOutputAddress` for misplaced expected and actual values in `require.Equal`.
 

--- a/persistence/test/application_test.go
+++ b/persistence/test/application_test.go
@@ -161,12 +161,12 @@ func TestGetAppPauseHeightIfExists(t *testing.T) {
 	// Check pause height when app does not exist
 	pauseHeight, err := db.GetAppPauseHeightIfExists(addrBz, 0)
 	require.Error(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 
 	// Check pause height when app does not exist
 	pauseHeight, err = db.GetAppPauseHeightIfExists(addrBz, 1)
 	require.NoError(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 }
 
 func TestSetAppPauseHeightAndUnstakeLater(t *testing.T) {
@@ -204,7 +204,7 @@ func TestGetAppOutputAddress(t *testing.T) {
 	require.NoError(t, err)
 	output, err := db.GetAppOutputAddress(addrBz, 0)
 	require.NoError(t, err)
-	require.Equal(t, hex.EncodeToString(output), app.Output, "unexpected output address")
+	require.Equal(t, app.Output, hex.EncodeToString(output), "unexpected output address")
 }
 
 func newTestApp() (*coreTypes.Actor, error) {

--- a/persistence/test/fisherman_test.go
+++ b/persistence/test/fisherman_test.go
@@ -151,12 +151,12 @@ func TestGetFishermanStatus(t *testing.T) {
 	// Check status before the fisherman exists
 	status, err := db.GetFishermanStatus(addrBz, 0)
 	require.Error(t, err)
-	require.Equal(t, status, persistence.UndefinedStakingStatus, "unexpected status")
+	require.Equal(t, persistence.UndefinedStakingStatus, status, "unexpected status")
 
 	// Check status after the fisherman exists
 	status, err = db.GetFishermanStatus(addrBz, 1)
 	require.NoError(t, err)
-	require.Equal(t, status, DefaultStakeStatus, "unexpected status")
+	require.Equal(t, DefaultStakeStatus, status, "unexpected status")
 }
 
 func TestGetFishermanPauseHeightIfExists(t *testing.T) {
@@ -171,12 +171,12 @@ func TestGetFishermanPauseHeightIfExists(t *testing.T) {
 	// Check pause height when fisherman does not exist
 	pauseHeight, err := db.GetFishermanPauseHeightIfExists(addrBz, 0)
 	require.Error(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 
 	// Check pause height when fisherman does not exist
 	pauseHeight, err = db.GetFishermanPauseHeightIfExists(addrBz, 1)
 	require.NoError(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 }
 
 func TestSetFishermanPauseHeightAndUnstakeLater(t *testing.T) {
@@ -217,7 +217,7 @@ func TestGetFishermanOutputAddress(t *testing.T) {
 
 	output, err := db.GetFishermanOutputAddress(addrBz, 0)
 	require.NoError(t, err)
-	require.Equal(t, hex.EncodeToString(output), fisherman.Output, "unexpected output address")
+	require.Equal(t, fisherman.Output, hex.EncodeToString(output), "unexpected output address")
 }
 
 func newTestFisherman() (*coreTypes.Actor, error) {

--- a/persistence/test/module_test.go
+++ b/persistence/test/module_test.go
@@ -45,7 +45,7 @@ func TestPersistenceContextParallelReadWrite(t *testing.T) {
 	contextBOriginalAmount, err := contextB.GetPoolAmount(poolName, 0)
 	require.NoError(t, err)
 	require.NotEqual(t, modifiedAmount, contextBOriginalAmount)
-	require.Equal(t, contextBOriginalAmount, contextAOriginalAmount)
+	require.Equal(t, contextAOriginalAmount, contextBOriginalAmount)
 }
 
 func TestPersistenceContextTwoWritesErrors(t *testing.T) {

--- a/persistence/test/service_node_test.go
+++ b/persistence/test/service_node_test.go
@@ -171,12 +171,12 @@ func TestGetServiceNodePauseHeightIfExists(t *testing.T) {
 	// Check pause height when serviceNode does not exist
 	pauseHeight, err := db.GetServiceNodePauseHeightIfExists(addrBz, 0)
 	require.Error(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 
 	// Check pause height when serviceNode does not exist
 	pauseHeight, err = db.GetServiceNodePauseHeightIfExists(addrBz, 1)
 	require.NoError(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 }
 
 func TestSetServiceNodePauseHeightAndUnstakeLater(t *testing.T) {
@@ -217,7 +217,7 @@ func TestGetServiceNodeOutputAddress(t *testing.T) {
 
 	output, err := db.GetServiceNodeOutputAddress(addrBz, 0)
 	require.NoError(t, err)
-	require.Equal(t, hex.EncodeToString(output), serviceNode.Output, "unexpected output address")
+	require.Equal(t, serviceNode.Output, hex.EncodeToString(output), "unexpected output address")
 }
 
 func newTestServiceNode() (*coreTypes.Actor, error) {

--- a/persistence/test/setup_test.go
+++ b/persistence/test/setup_test.go
@@ -219,8 +219,8 @@ func fuzzSingleProtocolActor(
 			if strings.Contains(newActor.StakedAmount, "invalid") {
 				log.Println("")
 			}
-			require.Equal(t, newActor.StakedAmount, newStakedTokens, "staked tokens not updated")
-			require.Equal(t, newActor.GenericParam, newActorSpecificParam, "actor specific param not updated")
+			require.Equal(t, newStakedTokens, newActor.StakedAmount, "staked tokens not updated")
+			require.Equal(t, newActorSpecificParam, newActor.GenericParam, "actor specific param not updated")
 		case "GetActorsReadyToUnstake":
 			unstakingActors, err := db.GetActorsReadyToUnstake(protocolActorSchema, db.Height)
 			require.NoError(t, err)

--- a/persistence/test/validator_test.go
+++ b/persistence/test/validator_test.go
@@ -169,12 +169,12 @@ func TestGetValidatorPauseHeightIfExists(t *testing.T) {
 	// Check pause height when validator does not exist
 	pauseHeight, err := db.GetValidatorPauseHeightIfExists(addrBz, 0)
 	require.Error(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 
 	// Check pause height when validator does not exist
 	pauseHeight, err = db.GetValidatorPauseHeightIfExists(addrBz, 1)
 	require.NoError(t, err)
-	require.Equal(t, pauseHeight, DefaultPauseHeight, "unexpected pause height")
+	require.Equal(t, DefaultPauseHeight, pauseHeight, "unexpected pause height")
 }
 
 func TestSetValidatorPauseHeightAndUnstakeLater(t *testing.T) {
@@ -215,7 +215,7 @@ func TestGetValidatorOutputAddress(t *testing.T) {
 
 	output, err := db.GetValidatorOutputAddress(addrBz, 0)
 	require.NoError(t, err)
-	require.Equal(t, hex.EncodeToString(output), validator.Output, "unexpected output address")
+	require.Equal(t, validator.Output, hex.EncodeToString(output), "unexpected output address")
 }
 
 func newTestValidator() (*coreTypes.Actor, error) {

--- a/utility/doc/CHANGELOG.md
+++ b/utility/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.21] - 2023-01-30
+
+- Updated `TestUtilityContext_SetPoolAmount`, `TestUtilityContext_GetMessageEditStakeSignerCandidates`, `TestUtilityContext_GetMessageUnpauseSignerCandidates`, `TestUtilityContext_GetMessageUnstakeSignerCandidates`, and `TestUtilityContext_UnstakePausedBefore` to correct misplaced expected and actual values in require.Equal.
+
 ## [0.0.0.20] - 2023-01-20
 
 - Remove `address []byte` argument from `InsertPool` function

--- a/utility/test/account_test.go
+++ b/utility/test/account_test.go
@@ -178,7 +178,7 @@ func TestUtilityContext_SetPoolAmount(t *testing.T) {
 	amount, err := ctx.GetPoolAmount(pool.GetAddress())
 	require.NoError(t, err)
 	require.NotEqual(t, beforeAmountBig, amount)
-	require.Equal(t, amount, expectedAfterAmount)
+	require.Equal(t, expectedAfterAmount, amount)
 	test_artifacts.CleanupTest(ctx)
 }
 

--- a/utility/test/actor_test.go
+++ b/utility/test/actor_test.go
@@ -361,7 +361,7 @@ func TestUtilityContext_GetMessageEditStakeSignerCandidates(t *testing.T) {
 			candidates, err := ctx.GetMessageEditStakeSignerCandidates(msgEditStake)
 			require.NoError(t, err)
 
-			require.Equal(t, len(candidates), 2, "unexpected number of candidates")
+			require.Equal(t, 2, len(candidates), "unexpected number of candidates")
 			require.Equal(t, actor.GetOutput(), hex.EncodeToString(candidates[0]), "incorrect output candidate")
 			require.Equal(t, actor.GetAddress(), hex.EncodeToString(candidates[1]), "incorrect addr candidate")
 
@@ -386,7 +386,7 @@ func TestUtilityContext_GetMessageUnpauseSignerCandidates(t *testing.T) {
 			candidates, err := ctx.GetMessageUnpauseSignerCandidates(msg)
 			require.NoError(t, err)
 
-			require.Equal(t, len(candidates), 2, "unexpected number of candidates")
+			require.Equal(t, 2, len(candidates), "unexpected number of candidates")
 			require.Equal(t, actor.GetOutput(), hex.EncodeToString(candidates[0]), "incorrect output candidate")
 			require.Equal(t, actor.GetAddress(), hex.EncodeToString(candidates[1]), "incorrect addr candidate")
 
@@ -411,7 +411,7 @@ func TestUtilityContext_GetMessageUnstakeSignerCandidates(t *testing.T) {
 			candidates, err := ctx.GetMessageUnstakeSignerCandidates(msg)
 			require.NoError(t, err)
 
-			require.Equal(t, len(candidates), 2, "unexpected number of candidates")
+			require.Equal(t, 2, len(candidates), "unexpected number of candidates")
 			require.Equal(t, actor.GetOutput(), hex.EncodeToString(candidates[0]), "incorrect output candidate")
 			require.Equal(t, actor.GetAddress(), hex.EncodeToString(candidates[1]), "incorrect addr candidate")
 
@@ -426,7 +426,7 @@ func TestUtilityContext_UnstakePausedBefore(t *testing.T) {
 			ctx := NewTestingUtilityContext(t, 1)
 
 			actor := getFirstActor(t, ctx, actorType)
-			require.Equal(t, actor.GetUnstakingHeight(), int64(-1), "wrong starting status")
+			require.Equal(t, int64(-1), actor.GetUnstakingHeight(), "wrong starting status")
 
 			addr := actor.GetAddress()
 			addrBz, err := hex.DecodeString(addr)
@@ -457,7 +457,7 @@ func TestUtilityContext_UnstakePausedBefore(t *testing.T) {
 			require.NoError(t, err, "error unstaking actor pause before height 1")
 
 			actor = getActorByAddr(t, ctx, actorType, addr)
-			require.Equal(t, actor.GetUnstakingHeight(), defaultUnstaking, "status does not equal unstaking")
+			require.Equal(t, defaultUnstaking, actor.GetUnstakingHeight(), "status does not equal unstaking")
 
 			var unstakingBlocks int64
 			switch actorType {


### PR DESCRIPTION
## Description
This PR fixes all the unit test functions in all modules where actual and expected values were misplaced in `require.Equal` check.

## Issue

Fixes #241

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [X] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Changes in consensus module - Fix `TestHotstuff4Nodes1BlockHappyPath` misplacement of actual and expected values in `require.Equal`.
- Changes in p2p module - Updated `TestRainTreeAddrBookUtilsHandleUpdate` and `testRainTreeMessageTargets` to correct incorrect expected and actual value placements.
- Changes in persistence module - Fix unit tests - `TestGetAppPauseHeightIfExists`, `TestGetAppOutputAddress`, `TestGetFishermanStatus`, `TestGetFishermanPauseHeightIfExists`, `TestGetFishermanOutputAddress`, `TestPersistenceContextParallelReadWrite`, `TestGetServiceNodePauseHeightIfExists`, `TestGetServiceNodeOutputAddress`, `fuzzSingleProtocolActor`, `TestGetValidatorPauseHeightIfExists`, and `TestGetValidatorOutputAddress` for misplaced expected and actual values in `require.Equal`.
- Changes in utility module - Updated `TestUtilityContext_SetPoolAmount`, `TestUtilityContext_GetMessageEditStakeSignerCandidates`, `TestUtilityContext_GetMessageUnpauseSignerCandidates`, `TestUtilityContext_GetMessageUnstakeSignerCandidates`, and `TestUtilityContext_UnstakePausedBefore` to correct misplaced expected and actual values in require.Equal.

## Testing

- [X] `make develop_test`
- [X] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have tested my changes using the available tooling
- [X] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
