### PR TITLE
[Tooling] Add example of The CLI is meant to be an user but also a ma…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,8 @@ develop_start: ## Run all of the make commands necessary to develop on the proje
 		make protogen_clean && make protogen_local && \
 		make go_clean_deps && \
 		make mockgen && \
-		make generate_rpc_openapi
+		make generate_rpc_openapi && \
+		make build
 
 .PHONY: develop_test
 develop_test: docker_check ## Run all of the make commands necessary to develop on the project and verify the tests pass

--- a/app/client/cli/account.go
+++ b/app/client/cli/account.go
@@ -9,9 +9,9 @@ import (
 )
 
 func init() {
-	accounCmd := NewAccountCommand()
-	accounCmd.Flags().StringVar(&pwd, "pwd", "", "passphrase used by the cmd, non empty usage bypass interactive prompt")
-	rootCmd.AddCommand(accounCmd)
+	accountCmd := NewAccountCommand()
+	accountCmd.Flags().StringVar(&pwd, "pwd", "", "passphrase used by the cmd, non empty usage bypass interactive prompt")
+	rootCmd.AddCommand(accountCmd)
 }
 
 func NewAccountCommand() *cobra.Command {

--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -48,10 +48,17 @@ var (
 	// Its purpose is to allow the CLI to "discover" the nodes in the network. Since currently we don't have churn and we run nodes only in LocalNet, we can rely on the genesis state.
 	// HACK(#416): This is a temporary solution that guarantees backward compatibility while we implement peer discovery
 	validators []*coreTypes.Actor
+
+	// While the `p1` binary is in development, the debug commands require a config and a debug genesis file to operate.
+	// These currently live inside of the pocket repo so a workdir needs to be specified if `p1` is used from a directory
+	// other than the root of the pocket repo.
+	workdir string = ""
 )
 
 func init() {
-	rootCmd.AddCommand(NewDebugCommand())
+	debugCmd := NewDebugCommand()
+	debugCmd.Flags().StringVar(&workdir, "workdir", "", "workdir where the pocket repo is located, relative to which config & genesis files can be loaded")
+	rootCmd.AddCommand(debugCmd)
 }
 
 func NewDebugCommand() *cobra.Command {
@@ -61,7 +68,7 @@ func NewDebugCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var err error
-			runtimeMgr := runtime.NewManagerFromFiles(defaultConfigPath, defaultGenesisPath, runtime.WithClientDebugMode(), runtime.WithRandomPK())
+			runtimeMgr := runtime.NewManagerFromFiles(workdir+defaultConfigPath, workdir+defaultGenesisPath, runtime.WithClientDebugMode(), runtime.WithRandomPK())
 
 			// HACK(#416): this is a temporary solution that guarantees backward compatibility while we implement peer discovery.
 			validators = runtimeMgr.GetGenesis().Validators

--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -25,8 +25,11 @@ const (
 	PromptTogglePacemakerMode    string = "TogglePacemakerMode"
 	PromptShowLatestBlockInStore string = "ShowLatestBlockInStore"
 
-	defaultConfigPath  = "build/config/config1.json"
-	defaultGenesisPath = "build/config/genesis.json"
+	defaultConfigPath = "build/config/config1.json"
+	// HACK: Note that `genesis.json` is a copy-pasta of `genesis_debug.json` with the only
+	// difference being that `node{X}.consensus:8080` is replaced with `localhost:808{X}` because
+	// container names cannot be resolved by Docker's DNS from the host.
+	defaultGenesisPath = "build/config/genesis_debug.json"
 )
 
 var (

--- a/build/config/genesis_debug.json
+++ b/build/config/genesis_debug.json
@@ -1,0 +1,259 @@
+{
+  "accounts": [
+    {
+      "address": "6f66574e1f50f0ef72dff748c3f11b9e0e89d32a",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "67eb3f0a50ae459fecf666be0e93176e92441317",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "3f52e08c4b3b65ab7cf098d77df5bf8cedcf5f99",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "113fdb095d42d6e09327ab5b8df13fd8197a1eaf",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "43d9ea9d9ad9c58bb96ec41340f83cb2cabb6496",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "9ba047197ec043665ad3f81278ab1f5d3eaf6b8b",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "88a792b7aca673620132ef01f50e62caa58eca83",
+      "amount": "100000000000000"
+    }
+  ],
+  "pools": [
+    {
+      "address": "DAO",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "FeeCollector",
+      "amount": "0"
+    },
+    {
+      "address": "AppStakePool",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "ValidatorStakePool",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "ServiceNodeStakePool",
+      "amount": "100000000000000"
+    },
+    {
+      "address": "FishermanStakePool",
+      "amount": "100000000000000"
+    }
+  ],
+  "validators": [
+    {
+      "address": "113fdb095d42d6e09327ab5b8df13fd8197a1eaf",
+      "public_key": "53ee26c82826694ffe1773d7b60d5f20dd9e91bdf8745544711bec5ff9c6fb4a",
+      "chains": null,
+      "generic_param": "localhost:8081",
+      "staked_amount": "1000000000000",
+      "paused_height": -1,
+      "unstaking_height": -1,
+      "output": "113fdb095d42d6e09327ab5b8df13fd8197a1eaf",
+      "actor_type": 4
+    },
+    {
+      "address": "3f52e08c4b3b65ab7cf098d77df5bf8cedcf5f99",
+      "public_key": "a8b6be75d7551da093f788f7286c3a9cb885cfc8e52710eac5f1d5e5b4bf19b2",
+      "chains": null,
+      "generic_param": "localhost:8082",
+      "staked_amount": "1000000000000",
+      "paused_height": -1,
+      "unstaking_height": -1,
+      "output": "3f52e08c4b3b65ab7cf098d77df5bf8cedcf5f99",
+      "actor_type": 4
+    },
+    {
+      "address": "67eb3f0a50ae459fecf666be0e93176e92441317",
+      "public_key": "c16043323c83ffd901a8bf7d73543814b8655aa4695f7bfb49d01926fc161cdb",
+      "chains": null,
+      "generic_param": "localhost:8083",
+      "staked_amount": "1000000000000",
+      "paused_height": -1,
+      "unstaking_height": -1,
+      "output": "67eb3f0a50ae459fecf666be0e93176e92441317",
+      "actor_type": 4
+    },
+    {
+      "address": "6f66574e1f50f0ef72dff748c3f11b9e0e89d32a",
+      "public_key": "b2eda2232ffb2750bf761141f70f75a03a025f65b2b2b417c7f8b3c9ca91e8e4",
+      "chains": null,
+      "generic_param": "localhost:8084",
+      "staked_amount": "1000000000000",
+      "paused_height": -1,
+      "unstaking_height": -1,
+      "output": "6f66574e1f50f0ef72dff748c3f11b9e0e89d32a",
+      "actor_type": 4
+    }
+  ],
+  "applications": [
+    {
+      "address": "88a792b7aca673620132ef01f50e62caa58eca83",
+      "public_key": "5f78658599943dc3e623539ce0b3c9fe4e192034a1e3fef308bc9f96915754e0",
+      "chains": ["0001"],
+      "generic_param": "1000000",
+      "staked_amount": "1000000000000",
+      "paused_height": -1,
+      "unstaking_height": -1,
+      "output": "88a792b7aca673620132ef01f50e62caa58eca83",
+      "actor_type": 1
+    }
+  ],
+  "service_nodes": [
+    {
+      "address": "43d9ea9d9ad9c58bb96ec41340f83cb2cabb6496",
+      "public_key": "16cd0a304c38d76271f74dd3c90325144425d904ef1b9a6fbab9b201d75a998b",
+      "chains": ["0001"],
+      "generic_param": "localhost:8081",
+      "staked_amount": "1000000000000",
+      "paused_height": -1,
+      "unstaking_height": -1,
+      "output": "43d9ea9d9ad9c58bb96ec41340f83cb2cabb6496",
+      "actor_type": 2
+    }
+  ],
+  "fishermen": [
+    {
+      "address": "9ba047197ec043665ad3f81278ab1f5d3eaf6b8b",
+      "public_key": "68efd26af01692fcd77dc135ca1de69ede464e8243e6832bd6c37f282db8c9cb",
+      "chains": ["0001"],
+      "generic_param": "localhost:8081",
+      "staked_amount": "1000000000000",
+      "paused_height": -1,
+      "unstaking_height": -1,
+      "output": "9ba047197ec043665ad3f81278ab1f5d3eaf6b8b",
+      "actor_type": 3
+    }
+  ],
+  "params": {
+    "blocks_per_session": 4,
+    "app_minimum_stake": "15000000000",
+    "app_max_chains": 15,
+    "app_baseline_stake_rate": 100,
+    "app_unstaking_blocks": 2016,
+    "app_minimum_pause_blocks": 4,
+    "app_max_pause_blocks": 672,
+    "service_node_minimum_stake": "15000000000",
+    "service_node_max_chains": 15,
+    "service_node_unstaking_blocks": 2016,
+    "service_node_minimum_pause_blocks": 4,
+    "service_node_max_pause_blocks": 672,
+    "service_nodes_per_session": 24,
+    "fisherman_minimum_stake": "15000000000",
+    "fisherman_max_chains": 15,
+    "fisherman_unstaking_blocks": 2016,
+    "fisherman_minimum_pause_blocks": 4,
+    "fisherman_max_pause_blocks": 672,
+    "validator_minimum_stake": "15000000000",
+    "validator_unstaking_blocks": 2016,
+    "validator_minimum_pause_blocks": 4,
+    "validator_max_pause_blocks": 672,
+    "validator_maximum_missed_blocks": 5,
+    "validator_max_evidence_age_in_blocks": 8,
+    "proposer_percentage_of_fees": 10,
+    "missed_blocks_burn_percentage": 1,
+    "double_sign_burn_percentage": 5,
+    "message_double_sign_fee": "10000",
+    "message_send_fee": "10000",
+    "message_stake_fisherman_fee": "10000",
+    "message_edit_stake_fisherman_fee": "10000",
+    "message_unstake_fisherman_fee": "10000",
+    "message_pause_fisherman_fee": "10000",
+    "message_unpause_fisherman_fee": "10000",
+    "message_fisherman_pause_service_node_fee": "10000",
+    "message_test_score_fee": "10000",
+    "message_prove_test_score_fee": "10000",
+    "message_stake_app_fee": "10000",
+    "message_edit_stake_app_fee": "10000",
+    "message_unstake_app_fee": "10000",
+    "message_pause_app_fee": "10000",
+    "message_unpause_app_fee": "10000",
+    "message_stake_validator_fee": "10000",
+    "message_edit_stake_validator_fee": "10000",
+    "message_unstake_validator_fee": "10000",
+    "message_pause_validator_fee": "10000",
+    "message_unpause_validator_fee": "10000",
+    "message_stake_service_node_fee": "10000",
+    "message_edit_stake_service_node_fee": "10000",
+    "message_unstake_service_node_fee": "10000",
+    "message_pause_service_node_fee": "10000",
+    "message_unpause_service_node_fee": "10000",
+    "message_change_parameter_fee": "10000",
+    "acl_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "blocks_per_session_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "app_minimum_stake_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "app_max_chains_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "app_baseline_stake_rate_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "app_staking_adjustment_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "app_unstaking_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "app_minimum_pause_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "app_max_paused_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "service_node_minimum_stake_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "service_node_max_chains_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "service_node_unstaking_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "service_node_minimum_pause_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "service_node_max_paused_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "service_nodes_per_session_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "fisherman_minimum_stake_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "fisherman_max_chains_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "fisherman_unstaking_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "fisherman_minimum_pause_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "fisherman_max_paused_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "validator_minimum_stake_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "validator_unstaking_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "validator_minimum_pause_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "validator_max_paused_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "validator_maximum_missed_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "validator_max_evidence_age_in_blocks_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "proposer_percentage_of_fees_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "missed_blocks_burn_percentage_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "double_sign_burn_percentage_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_double_sign_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_send_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_stake_fisherman_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_edit_stake_fisherman_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unstake_fisherman_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_pause_fisherman_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unpause_fisherman_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_fisherman_pause_service_node_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_test_score_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_prove_test_score_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_stake_app_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_edit_stake_app_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unstake_app_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_pause_app_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unpause_app_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_stake_validator_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_edit_stake_validator_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unstake_validator_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_pause_validator_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unpause_validator_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_stake_service_node_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_edit_stake_service_node_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unstake_service_node_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_pause_service_node_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_unpause_service_node_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45",
+    "message_change_parameter_fee_owner": "da034209758b78eaea06dd99c07909ab54c99b45"
+  },
+  "genesis_time": {
+    "seconds": 1663610702,
+    "nanos": 405401000
+  },
+  "chain_id": "testnet",
+  "max_block_bytes": 4000000
+}

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -99,6 +99,16 @@ The cli binary will be available at `bin/p1` and can be used instead of `go run 
 
 The commands available are listed [here](../../rpc/doc/README.md) or accessible via `bin/p1 --help`
 
+2.1 [OPTIONAL]: Add the binary to your `.rc`:
+
+You can add the following function so you can run the `p1` from anywhere on your host:
+
+```bash
+function p1 {
+    </your/path/to/pocket/repo>/bin/p1 "$@"
+}
+```
+
 ### Swagger UI
 
 Swagger UI is available to help during the development process.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -105,8 +105,12 @@ You can add the following function so you can run the `p1` from anywhere on your
 
 ```bash
 function p1 {
-    pocket_workdir="</your/path/to/pocket/repo>"
-    ${pocket_workdir}/bin/p1 "$@" --workdir=${pocket_workdir}
+    pocket_workdir="/Users/olshansky/workspace/pocket/pocket/"
+    if [ "$1" = "debug" ]; then
+        ${pocket_workdir}/bin/p1 debug --localhost=true --workdir="${pocket_workdir}"
+    else
+        ${pocket_workdir}/bin/p1 "$@"
+    fi
 }
 ```
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -99,13 +99,14 @@ The cli binary will be available at `bin/p1` and can be used instead of `go run 
 
 The commands available are listed [here](../../rpc/doc/README.md) or accessible via `bin/p1 --help`
 
-2.1 [OPTIONAL]: Add the binary to your `.rc`:
+2.1 [OPTIONAL] Add the binary to your `.rc`
 
 You can add the following function so you can run the `p1` from anywhere on your host:
 
 ```bash
 function p1 {
-    </your/path/to/pocket/repo>/bin/p1 "$@"
+    pocket_workdir="</your/path/to/pocket/repo>"
+    ${pocket_workdir}/bin/p1 "$@" --workdir=${pocket_workdir}
 }
 ```
 

--- a/p2p/providers/addrbook_provider/addrbook_provider.go
+++ b/p2p/providers/addrbook_provider/addrbook_provider.go
@@ -37,8 +37,6 @@ func ActorToNetworkPeer(abp AddrBookProvider, actor *coreTypes.Actor) (*typesP2P
 	conn, err := abp.GetConnFactory()(abp.GetP2PConfig(), actor.GetGenericParam()) // generic param is service url
 	if err != nil {
 		return nil, fmt.Errorf("error resolving addr: %v", err)
-	} else {
-		log.Printf("OLSH connected to %s", actor.GetGenericParam())
 	}
 
 	pubKey, err := cryptoPocket.NewPublicKey(actor.GetPublicKey())

--- a/p2p/providers/addrbook_provider/addrbook_provider.go
+++ b/p2p/providers/addrbook_provider/addrbook_provider.go
@@ -37,6 +37,8 @@ func ActorToNetworkPeer(abp AddrBookProvider, actor *coreTypes.Actor) (*typesP2P
 	conn, err := abp.GetConnFactory()(abp.GetP2PConfig(), actor.GetGenericParam()) // generic param is service url
 	if err != nil {
 		return nil, fmt.Errorf("error resolving addr: %v", err)
+	} else {
+		log.Printf("OLSH connected to %s", actor.GetGenericParam())
 	}
 
 	pubKey, err := cryptoPocket.NewPublicKey(actor.GetPublicKey())


### PR DESCRIPTION
## Description

Made the `p1` debug binary from localhost.

## Issue

NA

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Added `make build` to `make develop_start`
- Created a genesis file to be used from the host machine (not docker container)
- Added `localhost` and `workdir` to the `p1 debug` command so it can work not from within the docker container
- Updated the README with a bash helper other devs can use

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

https://user-images.githubusercontent.com/1892194/215901991-076734e5-bc94-4755-9f2a-3d1f3c1e4aef.mov

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
