### PR TITLE
[DOCS] Fix links to app module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All the links you'll need are listed below. If you'd like to contribute to the P
 - _Coming Soon: Consensus Architecture_ // TODO(olshansky): needs a README file with proper code structure
 - [Persistence Architecture](persistence/docs/README.md)
 - [P2P Architecture](p2p/README.md)
-- [CLI Architecture](app/client/cli/doc/README.md)
+- [APP Architecture](app/client/doc/README.md)
 - [RPC Architecture](app/pocket/rpc/doc/README.md)
 - [Node binary Architecture](app/pocket/doc/README.md)
 
@@ -52,7 +52,7 @@ All the links you'll need are listed below. If you'd like to contribute to the P
 - [Consensus Changelog](consensus/doc/CHANGELOG.md)
 - [Persistence Changelog](persistence/docs/CHANGELOG.md)
 - [P2P Changelog](p2p/CHANGELOG.md)
-- [CLI Changelog](app/client/cli/doc/CHANGELOG.md)
+- [APP Changelog](app/client/doc/CHANGELOG.md)
 - [RPC Changelog](app/pocket/rpc/doc/CHANGELOG.md)
 - [Node binary Changelog](app/pocket/doc/CHANGELOG.md)
 

--- a/app/client/doc/CHANGELOG.md
+++ b/app/client/doc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.6] - 2023-02-02
+
+## Added
+
+- Fix broken link to `shared/crypto/README.md` in keybase documentation
+
 ## [0.0.0.5] - 2023-02-02
 
 ### Added

--- a/app/client/keybase/README.md
+++ b/app/client/keybase/README.md
@@ -16,7 +16,7 @@ _TODO(#150): The current keybase has not been integrated with any CLI endpoints,
 
 The Keybase package uses a filesystem key-value database, `BadgerDB`, as its backend to persistently store keys locally on the client machine. The DB stores the local keys encoded as `[]byte` using `encoding/gob`.
 
-The `KeyPair` defined in [crypto package](../../../shared/core/crypto) is the data structure that's stored in the DB. Specifically:
+The `KeyPair` defined in [crypto package](../../../shared/crypto) is the data structure that's stored in the DB. Specifically:
 
 - **Key**: The `[]byte` returned by the `GetAddressBytes()` function is used as the key in the key-value store.
 - **Value**: The `gob` encoded struct of the entire `KeyPair`, containing both the `PublicKey` and `PrivKeyArmour` (JSON encoded, encrypted private key string), is the value.


### PR DESCRIPTION
## Description

Following the merge of #459 the `app/client/cli/doc` directory has moved to `app/client/doc` this PR fixes the links in the README

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Fix links to app documentation
- Change CLI to APP in links

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`


## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist
- [x] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
