### PR TITLE
[BUG] Tilt - Update permissions to avoid using sudo

### DIFF
--- a/build/Dockerfile.debian.dev
+++ b/build/Dockerfile.debian.dev
@@ -6,7 +6,6 @@ ARG TARGET_GOLANG_VERSION=1.19
 FROM golang:${TARGET_GOLANG_VERSION}-bullseye AS builder
 
 ENV PROTOC_VERSION 3.19.4
-ENV PATH $PATH:$GOPATH/bin
 # Needed to install Tilt without sudo permissions
 ENV PATH $PATH:$HOME/.local/bin
 

--- a/build/Dockerfile.debian.dev
+++ b/build/Dockerfile.debian.dev
@@ -7,6 +7,8 @@ FROM golang:${TARGET_GOLANG_VERSION}-bullseye AS builder
 
 ENV PROTOC_VERSION 3.19.4
 ENV PATH $PATH:$GOPATH/bin
+# Needed to install Tilt without sudo permissions
+ENV PATH $PATH:$HOME/.local/bin
 
 ### Install dependencies
 # Debian packages

--- a/build/Dockerfile.debian.prod
+++ b/build/Dockerfile.debian.prod
@@ -5,7 +5,6 @@ ARG TARGET_GOLANG_VERSION=1.19
 FROM golang:${TARGET_GOLANG_VERSION}-bullseye AS builder
 
 ENV PROTOC_VERSION 3.19.4
-ENV PATH $PATH:$GOPATH/bin
 # Needed to install Tilt without sudo permissions
 ENV PATH $PATH:$HOME/.local/bin
 

--- a/build/Dockerfile.debian.prod
+++ b/build/Dockerfile.debian.prod
@@ -6,6 +6,8 @@ FROM golang:${TARGET_GOLANG_VERSION}-bullseye AS builder
 
 ENV PROTOC_VERSION 3.19.4
 ENV PATH $PATH:$GOPATH/bin
+# Needed to install Tilt without sudo permissions
+ENV PATH $PATH:$HOME/.local/bin
 
 ### Install dependencies
 # Debian packages

--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.12] - 2023-02-08
+
+- Fix bug related to installing Tilt in the Docker containers
+
 ## [0.0.0.11] - 2023-02-07
 
 - Added GITHUB_WIKI tags where it was missing


### PR DESCRIPTION
## Description

Fix Tilt permissions issue

## Issue

Main build is broken as seen [here](https://github.com/pokt-network/pocket/actions/runs/4116795739/jobs/7107384911#step:7:894).

![Screenshot 2023-02-07 at 11 52 00 AM](https://user-images.githubusercontent.com/1892194/217350925-187b286d-1d96-4158-baf9-4072787efcf3.png)


## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Add `ENV PATH $PATH:$HOME/.local/bin` to `dev` and `prod` images