### PR TITLE
[WIP] SLIP-0010 HD Child Key Generation

### DIFF
--- a/app/client/keybase/README.md
+++ b/app/client/keybase/README.md
@@ -8,7 +8,7 @@ This document is intended to outline the current Keybase implementation used by 
   - [Keybase Code Structure](#keybase-code-structure)
 - [Makefile Testing Helper](#makefile-testing-helper)
 - [KeyPair Encryption \& Armouring](#keypair-encryption--armouring)
-- [SLIPS-0010 Child Key Generation](#slips-child-key-generation)
+- [SLIP-0010 Child Key Generation](#child-key-generation)
 - [TODO: Future Work](#todo-future-work)
 
 _TODO(#150): The current keybase has not been integrated with any CLI endpoints, and as such is only accessible through the [keybase interface](#keybase-interface)_
@@ -74,7 +74,7 @@ The [documentation in the crypto library](../../../shared/crypto/README.md) cove
 
 The primitives and functions defined there are heavily used throughout this package.
 
-## Slips Child Key Generation
+## Child Key Generation
 
 The [documentation in the crypto library](../../../shared/crypto/README.md) covers the specifics of the SLIPS-0010 implementation related to child key generation from a single master key
 

--- a/app/client/keybase/README.md
+++ b/app/client/keybase/README.md
@@ -8,6 +8,7 @@ This document is intended to outline the current Keybase implementation used by 
   - [Keybase Code Structure](#keybase-code-structure)
 - [Makefile Testing Helper](#makefile-testing-helper)
 - [KeyPair Encryption \& Armouring](#keypair-encryption--armouring)
+- [SLIPS-0010 Child Key Generation](#slips-child-key-generation)
 - [TODO: Future Work](#todo-future-work)
 
 _TODO(#150): The current keybase has not been integrated with any CLI endpoints, and as such is only accessible through the [keybase interface](#keybase-interface)_
@@ -72,6 +73,10 @@ The unit tests for the keybase are defined in [keybase_test.go](./keybase_test.g
 The [documentation in the crypto library](../../../shared/crypto/README.md) covers all of the details related to the `KeyPair` interface, as well as `PrivateKey` encryption, armouring and unarmouring.
 
 The primitives and functions defined there are heavily used throughout this package.
+
+## Slips Child Key Generation
+
+The [documentation in the crypto library](../../../shared/crypto/README.md) covers the specifics of the SLIPS-0010 implementation related to child key generation from a single master key
 
 ## TODO: Future Work
 

--- a/app/client/keybase/keybase.go
+++ b/app/client/keybase/keybase.go
@@ -14,6 +14,15 @@ type Keybase interface {
 	// Insert a new keypair from the JSON string of the encrypted private key into the DB
 	ImportFromJSON(jsonStr, passphrase string) error
 
+	// DISCUSSION: Is there a more appropriate way to handle the HD interactions?
+	// SLIPS-0010 Key Derivation
+	// Deterministically generate and return the child key
+	DeriveChildFromKey(masterAddrHex, passphrase string, childIndex int32) (crypto.KeyPair, error)
+	DeriveChildFromSeed(seed []byte, childIndex int32) (crypto.KeyPair, error)
+	// Store the derived child key in the keybase
+	StoreChildFromKey(masterAddrHex, masterPassphrase string, childIndex int32, childPassphrase, childHint string) error
+	StoreChildFromSeed(seed []byte, childIndex int32, childPassphrase, childHint string) error
+
 	// Accessors
 	Get(address string) (crypto.KeyPair, error)
 	GetPubKey(address string) (crypto.PublicKey, error)

--- a/app/client/keybase/keybase_test.go
+++ b/app/client/keybase/keybase_test.go
@@ -27,6 +27,10 @@ const (
 	testJSONPubString  = "408bec6320b540aa0cc86b3e633e214f2fd4dce4caa08f164fa3a9d3e577b46c"
 	testJSONPrivString = "3554119cec1c0c8c5b3845a5d3fc6346eb44ed21aab5c063ae9b6b1d38bec275408bec6320b540aa0cc86b3e633e214f2fd4dce4caa08f164fa3a9d3e577b46c"
 	testJSONString     = `{"kdf":"scrypt","salt":"197d2754445a7e5ce3e6c8d7b1d0ff6f","secparam":"12","hint":"pocket wallet","ciphertext":"B/AORJrSeQrR5ewQGel4FeCCXscoCsMUzq9gXAAxDqjXMmMxa7TedBTuemtO82JyTCoQWFHbGxRx8A7IoETNh5T5yBAjNNrr7DDkVrcfSAM3ez9lQem17DsfowCvRtmbesDlvbSZMRy8mQgClLqWRN+c6W/fPQ/lxLUy1G1A965U/uImcMXzSwbfqYrBPEux"}`
+
+	// SLIP-0010 Key
+	testSeedHex         = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+	testPrimarySlipAddr = "dbeed1c166fb8d1647559e4155eadeda2eca8c10"
 )
 
 func TestKeybase_CreateNewKey(t *testing.T) {
@@ -441,6 +445,17 @@ func TestKeybase_ExportJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, privKey.Address().String(), testAddr)
 	require.Equal(t, privKey.String(), testPrivString)
+}
+
+func TestKeybase_DerivePrimarySlipKey(t *testing.T) {
+	db := initDB(t)
+	defer stopDB(t, db)
+
+	seed, err := hex.DecodeString(testSeedHex)
+	require.NoError(t, err)
+	kp, err := crypto.DeriveKeyFromPath(crypto.PoktPrimaryAccountPath, seed, testPassphrase, testHint)
+	require.NoError(t, err)
+	require.Equal(t, kp.GetAddressString(), testPrimarySlipAddr)
 }
 
 func initDB(t *testing.T) Keybase {

--- a/app/client/keybase/keybase_test.go
+++ b/app/client/keybase/keybase_test.go
@@ -28,9 +28,8 @@ const (
 	testJSONPrivString = "3554119cec1c0c8c5b3845a5d3fc6346eb44ed21aab5c063ae9b6b1d38bec275408bec6320b540aa0cc86b3e633e214f2fd4dce4caa08f164fa3a9d3e577b46c"
 	testJSONString     = `{"kdf":"scrypt","salt":"197d2754445a7e5ce3e6c8d7b1d0ff6f","secparam":"12","hint":"pocket wallet","ciphertext":"B/AORJrSeQrR5ewQGel4FeCCXscoCsMUzq9gXAAxDqjXMmMxa7TedBTuemtO82JyTCoQWFHbGxRx8A7IoETNh5T5yBAjNNrr7DDkVrcfSAM3ez9lQem17DsfowCvRtmbesDlvbSZMRy8mQgClLqWRN+c6W/fPQ/lxLUy1G1A965U/uImcMXzSwbfqYrBPEux"}`
 
-	// SLIP-0010 Key
-	testSeedHex         = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
-	testPrimarySlipAddr = "dbeed1c166fb8d1647559e4155eadeda2eca8c10"
+	// SLIPS-0010
+	testChildAddr1 = "8b83d7057df7ac1d20a2f0aa0edadf206eb6764d"
 )
 
 func TestKeybase_CreateNewKey(t *testing.T) {
@@ -447,15 +446,68 @@ func TestKeybase_ExportJSON(t *testing.T) {
 	require.Equal(t, privKey.String(), testPrivString)
 }
 
-func TestKeybase_DerivePrimarySlipKey(t *testing.T) {
+func TestKeybase_DeriveChildFromKey(t *testing.T) {
 	db := initDB(t)
 	defer stopDB(t, db)
 
-	seed, err := hex.DecodeString(testSeedHex)
+	err := db.ImportFromString(testPrivString, testPassphrase, testHint)
 	require.NoError(t, err)
-	kp, err := crypto.DeriveKeyFromPath(crypto.PoktPrimaryAccountPath, seed, testPassphrase, testHint)
+
+	childKey, err := db.DeriveChildFromKey(testAddr, testPassphrase, 1)
 	require.NoError(t, err)
-	require.Equal(t, kp.GetAddressString(), testPrimarySlipAddr)
+	require.Equal(t, childKey.GetAddressString(), testChildAddr1)
+}
+
+func TestKeybase_DeriveChildFromSeed(t *testing.T) {
+	db := initDB(t)
+	defer stopDB(t, db)
+
+	err := db.ImportFromString(testPrivString, testPassphrase, testHint)
+	require.NoError(t, err)
+
+	kp, err := db.Get(testAddr)
+	require.NoError(t, err)
+
+	seed, err := kp.GetSeed(testPassphrase)
+	require.NoError(t, err)
+
+	childKey, err := db.DeriveChildFromSeed(seed, 1)
+	require.NoError(t, err)
+	require.Equal(t, childKey.GetAddressString(), testChildAddr1)
+}
+
+func TestKeybase_StoreChildFromKey(t *testing.T) {
+	db := initDB(t)
+	defer stopDB(t, db)
+
+	err := db.ImportFromString(testPrivString, testPassphrase, testHint)
+	require.NoError(t, err)
+
+	err = db.StoreChildFromKey(testAddr, testPassphrase, 1, testPassphrase, testHint)
+	require.NoError(t, err)
+
+	childKey, err := db.GetPrivKey(testChildAddr1, testPassphrase)
+	require.Equal(t, childKey.Address().String(), testChildAddr1)
+}
+
+func TestKeybase_StoreChildFromSeed(t *testing.T) {
+	db := initDB(t)
+	defer stopDB(t, db)
+
+	err := db.ImportFromString(testPrivString, testPassphrase, testHint)
+	require.NoError(t, err)
+
+	kp, err := db.Get(testAddr)
+	require.NoError(t, err)
+
+	seed, err := kp.GetSeed(testPassphrase)
+	require.NoError(t, err)
+
+	err = db.StoreChildFromSeed(seed, 1, testPassphrase, testHint)
+	require.NoError(t, err)
+
+	childKey, err := db.GetPrivKey(testChildAddr1, testPassphrase)
+	require.Equal(t, childKey.Address().String(), testChildAddr1)
 }
 
 func initDB(t *testing.T) Keybase {

--- a/app/client/keybase/keystore.go
+++ b/app/client/keybase/keystore.go
@@ -223,6 +223,136 @@ func (keybase *badgerKeybase) GetAll() (addresses []string, keyPairs []crypto.Ke
 	return addresses, keyPairs, nil
 }
 
+// Deterministically generate and return the ith child key from the masterAddrHex key stored in the keybase
+func (keybase *badgerKeybase) DeriveChildFromKey(masterAddrHex, passphrase string, childIndex int32) (crypto.KeyPair, error) {
+	privKey, err := keybase.GetPrivKey(masterAddrHex, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	seed := privKey.Seed()
+	path := fmt.Sprintf(crypto.PoktAccountPathFormat, childIndex)
+	childKey, err := crypto.DeriveKeyFromPath(path, seed)
+	if err != nil {
+		return nil, err
+	}
+	return childKey, nil
+}
+
+// Deterministically generate and return the ith child from the seed provided
+func (keybase *badgerKeybase) DeriveChildFromSeed(seed []byte, childIndex int32) (crypto.KeyPair, error) {
+	path := fmt.Sprintf(crypto.PoktAccountPathFormat, childIndex)
+	childKey, err := crypto.DeriveKeyFromPath(path, seed)
+	if err != nil {
+		return nil, err
+	}
+	return childKey, nil
+}
+
+// Deterministically generate and store the ith child from the masterAddrHex key stored in the keybase
+func (keybase *badgerKeybase) StoreChildFromKey(masterAddrHex, masterPassphrase string, childIndex int32, childPassphrase, childHint string) error {
+	masterPrivKey, err := keybase.GetPrivKey(masterAddrHex, masterPassphrase)
+	if err != nil {
+		return err
+	}
+	seed := masterPrivKey.Seed()
+	path := fmt.Sprintf(crypto.PoktAccountPathFormat, childIndex)
+	childKey, err := crypto.DeriveKeyFromPath(path, seed)
+	if err != nil {
+		return err
+	}
+	// No need to re-encrypt with provided passphrase
+	if childPassphrase == "" && childHint == "" {
+		err = keybase.db.Update(func(tx *badger.Txn) error {
+			// Use key address as key in DB
+			addrKey := childKey.GetAddressBytes()
+
+			// Encode KeyPair into []byte for value
+			keypairBz, err := childKey.Marshal()
+			if err != nil {
+				return err
+			}
+
+			return tx.Set(addrKey, keypairBz)
+		})
+	} else {
+		// Re-encrypt child key with passphrase and hint
+		err = keybase.db.Update(func(tx *badger.Txn) error {
+			// Get the private key hex string from the child key
+			privKeyHex, err := childKey.ExportString("") // No passphrase by default
+			if err != nil {
+				return err
+			}
+
+			keyPair, err := crypto.CreateNewKeyFromString(privKeyHex, childPassphrase, childHint)
+			if err != nil {
+				return err
+			}
+
+			// Use key address as key in DB
+			addrKey := keyPair.GetAddressBytes()
+
+			// Encode KeyPair into []byte for value
+			keypairBz, err := keyPair.Marshal()
+			if err != nil {
+				return err
+			}
+
+			return tx.Set(addrKey, keypairBz)
+		})
+	}
+	return nil
+}
+
+// Deterministically generate and store the ith child from the masterAddrHex key stored in the keybase
+func (keybase *badgerKeybase) StoreChildFromSeed(seed []byte, childIndex int32, childPassphrase, childHint string) error {
+	path := fmt.Sprintf(crypto.PoktAccountPathFormat, childIndex)
+	childKey, err := crypto.DeriveKeyFromPath(path, seed)
+	if err != nil {
+		return err
+	}
+	// No need to re-encrypt with provided passphrase
+	if childPassphrase == "" && childHint == "" {
+		err = keybase.db.Update(func(tx *badger.Txn) error {
+			// Use key address as key in DB
+			addrKey := childKey.GetAddressBytes()
+
+			// Encode KeyPair into []byte for value
+			keypairBz, err := childKey.Marshal()
+			if err != nil {
+				return err
+			}
+
+			return tx.Set(addrKey, keypairBz)
+		})
+	} else {
+		// Re-encrypt child key with passphrase and hint
+		err = keybase.db.Update(func(tx *badger.Txn) error {
+			// Get the private key hex string from the child key
+			privKeyHex, err := childKey.ExportString("") // No passphrase by default
+			if err != nil {
+				return err
+			}
+
+			keyPair, err := crypto.CreateNewKeyFromString(privKeyHex, childPassphrase, childHint)
+			if err != nil {
+				return err
+			}
+
+			// Use key address as key in DB
+			addrKey := keyPair.GetAddressBytes()
+
+			// Encode KeyPair into []byte for value
+			keypairBz, err := keyPair.Marshal()
+			if err != nil {
+				return err
+			}
+
+			return tx.Set(addrKey, keypairBz)
+		})
+	}
+	return nil
+}
+
 // Check whether an address is currently stored in the DB
 func (keybase *badgerKeybase) Exists(address string) (bool, error) {
 	val, err := keybase.Get(address)

--- a/shared/crypto/README.md
+++ b/shared/crypto/README.md
@@ -3,7 +3,7 @@
 - [KeyPair Interface](#keypair-interface)
   - [KeyPair Code Structure](#keypair-code-structure)
 - [Encryption and Armouring](#encryption-and-armouring)
-- [Child Key Generation](#slips-0010-hd-child-key-generation)
+- [Child Key Generation](#slip-0010-hd-child-key-generation)
 
 _DOCUMENT: Note that this README is a WIP and does not exhaustively document all the current types in this package_
 
@@ -105,9 +105,9 @@ flowchart LR
     AES-GCM-->PrivateKey
 ```
 
-## SLIPS-0010 HD Child Key Generation
+## SLIP-0010 HD Child Key Generation
 
-[SLIPS-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) key generation from a master key or seed is supported through the file [slip.go](./slip.go)
+[SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) key generation from a master key or seed is supported through the file [slip.go](./slip.go)
 
 The keys are generated using the BIP-44 path `m/44'/635'/%d'` where `%d` is the index of the child key - this allows for the deterministic generation of up to `2147483647` hardened ed25519 child keys per master key.
 

--- a/shared/crypto/keypair.go
+++ b/shared/crypto/keypair.go
@@ -30,6 +30,9 @@ type KeyPair interface {
 	ExportString(passphrase string) (string, error)
 	ExportJSON(passphrase string) (string, error)
 
+	// Seed
+	GetSeed(passphrase string) ([]byte, error)
+
 	// Marshalling
 	Marshal() ([]byte, error)
 	Unmarshal([]byte) error
@@ -97,6 +100,15 @@ func (kp encKeyPair) ExportJSON(passphrase string) (string, error) {
 		return "", err
 	}
 	return kp.PrivKeyArmour, nil
+}
+
+// Return the seed of the key
+func (kp encKeyPair) GetSeed(passphrase string) ([]byte, error) {
+	privKey, err := unarmourDecryptPrivKey(kp.PrivKeyArmour, passphrase)
+	if err != nil {
+		return []byte{}, err
+	}
+	return privKey.Seed(), nil
 }
 
 // Marshal KeyPair into a []byte

--- a/shared/crypto/slip.go
+++ b/shared/crypto/slip.go
@@ -1,0 +1,157 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/binary"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// PoktAccountPrefix is the prefix used for HD key derivation where 635 is the SLIP-0044 coin type
+	PoktAccountPrefix = "m/44'/635'"
+	// PoktPrimaryAccountPath is the derivation path for the primary account
+	PoktPrimaryAccountPath = "m/44'/635'/0'"
+	// PoktAccountPathFormat is to be used with fmt.Sprintf to generate child keys
+	PoktAccountPathFormat = "m/44'/635'/%d"
+	// FirstHardenedKey is the index for the first hardened key for ed25519 keys
+	FirstHardenedKey = uint32(0x80000000)
+	MaxHardenedKey   = ^uint32(0)
+	// As defined in: https://github.com/satoshilabs/slips/blob/master/slip-0010.md#master-key-generation
+	seedModifier = "ed25519 seed"
+)
+
+var (
+	ErrInvalidPath  = fmt.Errorf("invalid BIP-44 derivation path")
+	ErrNoDerivation = fmt.Errorf("no derivation for an ed25519 key is possible")
+	pathRegex       = regexp.MustCompile(`m(\/[0-9]+')+$`)
+)
+
+type slipKey struct {
+	SecretKey []byte
+	ChainCode []byte
+}
+
+// Derives a key from a BIP-44 path and a seed only operating on hardened ed25519 keys
+func DeriveKeyFromPath(path string, seed []byte, passphrase, hint string) (KeyPair, error) {
+	segments, err := pathToSegments(path)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := NewMasterKey(seed)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i32 := range segments {
+		// Force hardened keys
+		if i32 >= MaxHardenedKey-FirstHardenedKey {
+			return nil, fmt.Errorf("hardened key index too large, max: %d, got: %d", MaxHardenedKey-FirstHardenedKey, i32)
+		}
+		i := i32 + FirstHardenedKey
+
+		// Derive the correct child until final segment
+		key, err = key.DeriveChild(i)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return key.ConvertToKeypair(passphrase, hint)
+}
+
+// Reference: https://github.com/satoshilabs/slips/blob/master/slip-0010.md#master-key-generation
+func NewMasterKey(seed []byte) (*slipKey, error) {
+	// Create HMAC hash from curve and seed
+	hmacHash := hmac.New(sha512.New, []byte(seedModifier))
+	if _, err := hmacHash.Write(seed); err != nil {
+		return nil, err
+	}
+
+	// Convert hash to []byte
+	sum := hmacHash.Sum(nil)
+
+	// Create SLIP-0010 Master key
+	key := &slipKey{
+		SecretKey: sum[:32],
+		ChainCode: sum[32:],
+	}
+
+	return key, nil
+}
+
+// Reference: https://github.com/satoshilabs/slips/blob/master/slip-0010.md#private-parent-key--private-child-key
+func (k *slipKey) DeriveChild(i uint32) (*slipKey, error) {
+	// Check i>=2^31 or else no public key can be derived for the ed25519 key
+	if i < FirstHardenedKey {
+		return nil, ErrNoDerivation
+	}
+
+	// i is a hardened child compute the HMAC hash of the key
+	iBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(iBytes, i)
+	key := append([]byte{0x0}, k.SecretKey...)
+	data := append(key, iBytes...)
+
+	hmacHash := hmac.New(sha512.New, k.ChainCode)
+	if _, err := hmacHash.Write(data); err != nil {
+		return nil, err
+	}
+
+	// Convert hash to []byte
+	sum := hmacHash.Sum(nil)
+
+	// Create SLIP-0010 Child key
+	child := &slipKey{
+		SecretKey: sum[:32],
+		ChainCode: sum[32:],
+	}
+	return child, nil
+}
+
+func (k *slipKey) ConvertToKeypair(passphrase, hint string) (KeyPair, error) {
+	// Generate PrivateKey interface form secret key
+	reader := bytes.NewReader(k.SecretKey)
+	privKey, err := GeneratePrivateKeyWithReader(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Armour and encrypt private key into JSON string
+	armouredStr, err := encryptArmourPrivKey(privKey, passphrase, hint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return KeyPair interface
+	return &encKeyPair{
+		PublicKey:     privKey.PublicKey(),
+		PrivKeyArmour: armouredStr,
+	}, nil
+}
+
+// Check the BIP-44 path provided is valid and return the []uint32 segments it contains
+func pathToSegments(path string) ([]uint32, error) {
+	// Check whether the path is valid
+	if !pathRegex.MatchString(path) {
+		return nil, ErrInvalidPath
+	}
+
+	// Split into segments and check for valid uint32 types
+	segments := make([]uint32, 0)
+	segs := strings.Split(path, "/")
+	for _, seg := range segs[1:] {
+		ui64, err := strconv.ParseUint(strings.TrimRight(seg, "'"), 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		segments = append(segments, uint32(ui64))
+	}
+
+	return segments, nil
+}


### PR DESCRIPTION
## Description

This PR contains an implementation of [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) which allows for deterministic child key generation from a master key. This is done by using the seed of the master key and creating a `hmac` hash using the `sha512` hashing function. The hash is split into 2 `[]byte` slices representing the `SecretKey` and the `ChainCode`.

This `hmac` key can then be used to deterministically generate keys within the BIP-44 path `m/44'/635'/%d'/`. `44` referring to the BIP-44 hardened key purpose of the path and `635'` is the coin type for Pocket Network. `%d` can be any number between `0-2147483647` inclusive. Allowing for a large number of child keys to be deterministically generated and retrieved by index from a single master key's seed.

_NOTE_ All the child keys are hardened ed25519 keys. They are then converted into an encrypted `KeyPair` interface following the same pattern already found in the keybase.

Some documentation on this process can be seen [here](https://github.com/pokt-network/pocket/blob/slip-0010-keys/shared/crypto/README.md#slip-0010-hd-child-key-generation)


## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Implement SLIP-0010
- Integrate child key generation with the keybase
- Add unit tests for child generation
- Update documentation

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [x] I have updated the corresponding README(s); local and/or global
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
