### PR TITLE
[Consensus] patch: consensus interface updates in test

### DIFF
--- a/consensus/e2e_tests/pacemaker_test.go
+++ b/consensus/e2e_tests/pacemaker_test.go
@@ -182,7 +182,8 @@ func TestPacemakerCatchupSameStepDifferentRounds(t *testing.T) {
 		consensusModImpl := GetConsensusModImpl(pocketNode)
 		consensusModImpl.MethodByName("SetHeight").Call([]reflect.Value{reflect.ValueOf(testHeight)})
 		consensusModImpl.MethodByName("SetStep").Call([]reflect.Value{reflect.ValueOf(testStep)})
-		consensusModImpl.MethodByName("SetLeaderId").Call([]reflect.Value{reflect.Zero(reflect.TypeOf(&leaderId))})
+		uintLeaderId := uint64(leaderId)
+		consensusModImpl.MethodByName("SetLeaderId").Call([]reflect.Value{reflect.ValueOf(uintLeaderId)})
 
 		// utilityContext is only set on new rounds, which is skipped in this test
 		utilityContext, err := pocketNode.GetBus().GetUtilityModule().NewContext(int64(testHeight))


### PR DESCRIPTION
## Description

Attempt to fix failing consensus test introduced in #531.

## Issue

![image](https://user-images.githubusercontent.com/600733/220881704-ed9622c7-ad75-4690-9413-b273502e4479.png)


```
--- FAIL: TestPacemakerCatchupSameStepDifferentRounds (0.01s)
panic: reflect: Call using *types.NodeId as type uint64 [recovered]
	panic: reflect: Call using *types.NodeId as type uint64

goroutine 34 [running]:
testing.tRunner.func1.2({0xb1a5a0, 0xc00037fa90})
	/usr/lib/go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1529 +0x39f
panic({0xb1a5a0, 0xc00037fa90})
	/usr/lib/go/src/runtime/panic.go:884 +0x213
reflect.Value.call({0xc23580?, 0xc000142300?, 0x1c?}, {0xc2b3b3, 0x4}, {0xc0000ebee8, 0x1, 0xd44798?})
	/usr/lib/go/src/reflect/value.go:442 +0x1a9f
reflect.Value.Call({0xc23580?, 0xc000142300?, 0x0?}, {0xc0000ebee8?, 0x0?, 0x0?})
	/usr/lib/go/src/reflect/value.go:370 +0xbc
github.com/pokt-network/pocket/consensus/e2e_tests.TestPacemakerCatchupSameStepDifferentRounds(0x4087f9?)
	/home/bwhite/Projects/pokt/pocket/consensus/e2e_tests/pacemaker_test.go:185 +0x885
```

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

<!-- REMOVE this comment block after following the instructions
 List out all the changes made
-->

- Cast leader ID to the new type before passing to `SetLeaderId`.


## Testing

- [ ] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
