### PR TITLE
[Logger] Replace logger values with pointers

### DIFF
--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.33] - 2023-02-24
+
+- Update logger value references with pointers
+
 ## [0.0.0.32] - 2023-02-22
 
 - Move functions exposed by ConsensusDebugModule to debugging.go

--- a/consensus/module.go
+++ b/consensus/module.go
@@ -70,7 +70,7 @@ type consensusModule struct {
 	paceMaker         pacemaker.Pacemaker
 	leaderElectionMod leader_election.LeaderElectionModule
 
-	logger    modules.Logger
+	logger    *modules.Logger
 	logPrefix string
 
 	stateSync state_sync.StateSyncModule

--- a/consensus/pacemaker/module.go
+++ b/consensus/pacemaker/module.go
@@ -54,7 +54,7 @@ type pacemaker struct {
 	// Only used for development and debugging.
 	debug pacemakerDebug
 
-	logger modules.Logger
+	logger *modules.Logger
 	// REFACTOR: logPrefix should be removed in exchange for setting a namespace directly with the logger
 	logPrefix string
 }

--- a/consensus/state_sync/module.go
+++ b/consensus/state_sync/module.go
@@ -51,7 +51,7 @@ type stateSync struct {
 	currentMode SyncMode
 	serverMode  bool
 
-	logger    modules.Logger
+	logger    *modules.Logger
 	logPrefix string
 }
 

--- a/logger/docs/CHANGELOG.md
+++ b/logger/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.8] - 2023-02-24
+
+- Update the logger module interface to use logger pointers instead of values
+- Update logger value references with pointers
+- Update README
+
 ## [0.0.0.7] - 2023-02-17
 
 - Module embeds `base_modules.IntegratableModule` and `base_modules.InterruptableModule` for DRYness

--- a/logger/docs/README.md
+++ b/logger/docs/README.md
@@ -101,7 +101,7 @@ Each module should have its own logger to appropriately namespace the logs.
 
 ```golang
 type sweetModule struct {
-    logger    modules.Logger
+    logger    *modules.Logger
 }
 
 func (m *sweetModule) DoSomething() {
@@ -119,7 +119,7 @@ Please initiate loggers in the `Start` method of the module, like this:
 
 ```golang
 type sweetModule struct {
-    logger    modules.Logger
+    logger    *modules.Logger
 }
 
 func (m *sweetModule) Start() error {

--- a/logger/module.go
+++ b/logger/module.go
@@ -57,10 +57,7 @@ func Create(bus modules.Bus, options ...modules.ModuleOption) (modules.Module, e
 	return new(loggerModule).Create(bus, options...)
 }
 
-// CreateLoggerForModule returns the logger with additional context (e.g. module name)
-// (see: https://github.com/rs/zerolog#sub-loggers-let-you-chain-loggers-with-additional-context)
-// NB: returns a pointer to mitigate `hugParam` linter error.
-// (see: https://golangci-lint.run/usage/linters/#gocritic)
+// CreateLoggerForModule implements the respective `modules.Logger` interface member.
 func (*loggerModule) CreateLoggerForModule(moduleName string) *modules.Logger {
 	logger := Global.Logger.With().Str("module", moduleName).Logger()
 	return &logger

--- a/logger/module.go
+++ b/logger/module.go
@@ -57,8 +57,13 @@ func Create(bus modules.Bus, options ...modules.ModuleOption) (modules.Module, e
 	return new(loggerModule).Create(bus, options...)
 }
 
-func (*loggerModule) CreateLoggerForModule(moduleName string) modules.Logger {
-	return Global.Logger.With().Str("module", moduleName).Logger()
+// CreateLoggerForModule returns the logger with additional context (e.g. module name)
+// (see: https://github.com/rs/zerolog#sub-loggers-let-you-chain-loggers-with-additional-context)
+// NB: returns a pointer to mitigate `hugParam` linter error.
+// (see: https://golangci-lint.run/usage/linters/#gocritic)
+func (*loggerModule) CreateLoggerForModule(moduleName string) *modules.Logger {
+	logger := Global.Logger.With().Str("module", moduleName).Logger()
+	return &logger
 }
 
 func (*loggerModule) Create(bus modules.Bus, options ...modules.ModuleOption) (modules.Module, error) {
@@ -98,7 +103,7 @@ func (*loggerModule) Create(bus modules.Bus, options ...modules.ModuleOption) (m
 }
 
 func (m *loggerModule) Start() error {
-	Global.Logger = m.CreateLoggerForModule("global")
+	Global.Logger = *m.CreateLoggerForModule("global")
 	return nil
 }
 

--- a/p2p/CHANGELOG.md
+++ b/p2p/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.29] - 2023-02-24
+
+- Update logger value references with pointers
+
 ## [0.0.0.28] - 2023-02-20
 
 - Added basic `bootstrap` nodes support

--- a/p2p/module.go
+++ b/p2p/module.go
@@ -29,7 +29,7 @@ type p2pModule struct {
 	listener typesP2P.Transport
 	address  cryptoPocket.Address
 
-	logger modules.Logger
+	logger *modules.Logger
 
 	network typesP2P.Network
 

--- a/p2p/raintree/network.go
+++ b/p2p/raintree/network.go
@@ -32,7 +32,7 @@ type rainTreeNetwork struct {
 
 	currentHeightProvider providers.CurrentHeightProvider
 
-	logger modules.Logger
+	logger *modules.Logger
 }
 
 func NewRainTreeNetwork(addr cryptoPocket.Address, bus modules.Bus, addrBookProvider providers.AddrBookProvider, currentHeightProvider providers.CurrentHeightProvider) typesP2P.Network {

--- a/p2p/stdnetwork/network.go
+++ b/p2p/stdnetwork/network.go
@@ -20,7 +20,7 @@ var (
 type network struct {
 	addrBookMap typesP2P.AddrBookMap
 
-	logger modules.Logger
+	logger *modules.Logger
 }
 
 func NewNetwork(bus modules.Bus, addrBookProvider providers.AddrBookProvider, currentHeightProvider providers.CurrentHeightProvider) (n typesP2P.Network) {

--- a/persistence/context.go
+++ b/persistence/context.go
@@ -21,7 +21,7 @@ type PostgresContext struct {
 
 	stateHash string
 
-	logger modules.Logger
+	logger *modules.Logger
 
 	// TECHDEBT(#361): These three values are pointers to objects maintained by the PersistenceModule.
 	//                 Need to simply access them via the bus.

--- a/persistence/context.go
+++ b/persistence/context.go
@@ -97,7 +97,6 @@ func (p *PostgresContext) Release() error {
 }
 
 func (p *PostgresContext) Close() error {
-	p.logger.Info().Int64("height", p.Height).Msg("About to close postgres context")
 	return p.conn.Close(context.TODO())
 }
 

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.38] - 2023-02-24
+
+- Update logger value references with pointers
+- Remove unnecessary (and problematic) logger calls
+
 ## [0.0.0.37] - 2023-02-21
 
 - Rename ServiceNode Actor Type Name to Servicer

--- a/persistence/genesis.go
+++ b/persistence/genesis.go
@@ -13,8 +13,6 @@ import (
 
 // CONSIDERATION: Should this return an error and let the caller decide if it should log a fatal error?
 func (m *persistenceModule) populateGenesisState(state *genesis.GenesisState) {
-	m.logger.Info().Msg("Populating genesis state...")
-
 	// REFACTOR: This business logic should probably live in `types/genesis.go`
 	//           and we need to add proper unit tests for it.`
 	poolValues := make(map[string]*big.Int, 0)

--- a/persistence/module.go
+++ b/persistence/module.go
@@ -33,7 +33,7 @@ type persistenceModule struct {
 	txIndexer  indexer.TxIndexer
 	stateTrees *stateTrees
 
-	logger modules.Logger
+	logger *modules.Logger
 
 	// TECHDEBT: Need to implement context pooling (for writes), timeouts (for read & writes), etc...
 	writeContext *PostgresContext // only one write context is allowed at a time

--- a/persistence/module.go
+++ b/persistence/module.go
@@ -109,7 +109,6 @@ func (*persistenceModule) Create(bus modules.Bus, options ...modules.ModuleOptio
 }
 
 func (m *persistenceModule) Start() error {
-	m.logger.Info().Msg("Starting module...")
 	m.logger = logger.Global.CreateLoggerForModule(m.GetModuleName())
 	return nil
 }

--- a/persistence/module.go
+++ b/persistence/module.go
@@ -48,6 +48,12 @@ func (*persistenceModule) Create(bus modules.Bus, options ...modules.ModuleOptio
 		writeContext: nil,
 	}
 
+	// TECHDEBT: move to `persistenceModule#Start` as per documentation.
+	// Temporarily moving this here as long as there are references to
+	// the logger in methods which are called by `#Create` (i.e.
+	// `persistenceModule#populateGenesisState`, `postgresContext#Commit`)
+	m.logger = logger.Global.CreateLoggerForModule(m.GetModuleName())
+
 	for _, option := range options {
 		option(m)
 	}
@@ -109,7 +115,6 @@ func (*persistenceModule) Create(bus modules.Bus, options ...modules.ModuleOptio
 }
 
 func (m *persistenceModule) Start() error {
-	m.logger = logger.Global.CreateLoggerForModule(m.GetModuleName())
 	return nil
 }
 

--- a/rpc/doc/CHANGELOG.md
+++ b/rpc/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.14] - 2023-02-24
+
+- Update logger value references with pointers
+
 ## [0.0.0.13] - 2023-02-21
 
 - Rename ServiceNode Actor Type Name to Servicer

--- a/rpc/module.go
+++ b/rpc/module.go
@@ -18,7 +18,7 @@ type rpcModule struct {
 	base_modules.IntegratableModule
 	base_modules.InterruptableModule
 
-	logger modules.Logger
+	logger *modules.Logger
 	config *configs.RPCConfig
 }
 
@@ -48,7 +48,7 @@ func (*rpcModule) Create(bus modules.Bus, options ...modules.ModuleOption) (modu
 
 func (u *rpcModule) Start() error {
 	u.logger = logger.Global.CreateLoggerForModule(u.GetModuleName())
-	go NewRPCServer(u.GetBus()).StartRPC(u.config.Port, u.config.Timeout, &u.logger)
+	go NewRPCServer(u.GetBus()).StartRPC(u.config.Port, u.config.Timeout, u.logger)
 	return nil
 }
 

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.33] - 2023-02-24
+
+- Update logger value references with pointers
+
 ## [0.0.0.32] - 2023-02-23
 
 - Add file utility functions for checking, reading and writing to files

--- a/shared/modules/logger_module.go
+++ b/shared/modules/logger_module.go
@@ -15,7 +15,9 @@ type LoggerModule interface {
 	// TODO(#288): Embed `ObservableModule` inside of the `Module` interface so each module has its own context specific logger
 	ObservableModule
 
-	// `CreateLoggerForModule` returns the logger with additional context (e.g. module name)
-	// https://github.com/rs/zerolog#sub-loggers-let-you-chain-loggers-with-additional-context
-	CreateLoggerForModule(string) Logger
+	// CreateLoggerForModule returns the logger with additional context (e.g. module name)
+	// (see: https://github.com/rs/zerolog#sub-loggers-let-you-chain-loggers-with-additional-context)
+	// NB: returns a pointer to mitigate `hugParam` linter error.
+	// (see: https://golangci-lint.run/usage/linters/#gocritic)
+	CreateLoggerForModule(string) *Logger
 }

--- a/state_machine/docs/CHANGELOG.md
+++ b/state_machine/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.2] - 2023-02-24
+
+- Update logger value references with pointers
+
 ## [0.0.0.1] - 2023-02-17
 
 - Introduced this `CHANGELOG.md` and  `README.md`

--- a/state_machine/module.go
+++ b/state_machine/module.go
@@ -18,7 +18,7 @@ type stateMachineModule struct {
 	base_modules.InterruptableModule
 
 	*fsm.FSM
-	logger modules.Logger
+	logger *modules.Logger
 }
 
 func Create(bus modules.Bus, options ...modules.ModuleOption) (modules.Module, error) {

--- a/telemetry/CHANGELOG.md
+++ b/telemetry/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.9] - 2023-02-24
+
+- Update logger value references with pointers
+
 ## [0.0.0.8] - 2023-02-17
 
 - Modules embed `base_modules.IntegratableModule` and `base_modules.InterruptableModule` for DRYness

--- a/telemetry/prometheus_module.go
+++ b/telemetry/prometheus_module.go
@@ -29,7 +29,7 @@ type PrometheusTelemetryModule struct {
 
 	config *configs.TelemetryConfig
 
-	logger modules.Logger
+	logger *modules.Logger
 
 	counters     map[string]prometheus.Counter
 	gauges       map[string]prometheus.Gauge

--- a/utility/context.go
+++ b/utility/context.go
@@ -15,7 +15,7 @@ type utilityContext struct {
 	savePointsSet      map[string]struct{}
 	savePointsList     [][]byte
 
-	logger modules.Logger
+	logger *modules.Logger
 
 	// TECHDEBT: Consolidate all these types with the shared Protobuf struct and create a `proposalBlock`
 	proposalProposerAddr []byte

--- a/utility/doc/CHANGELOG.md
+++ b/utility/doc/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.30] - 2023-02-24
+
+- Update logger value references with pointers
+- Fix module test after logger refactor
+
 ## [0.0.0.29] - 2023-02-21
 
 - Rename ServiceNode Actor Type Name to Servicer

--- a/utility/module.go
+++ b/utility/module.go
@@ -20,7 +20,7 @@ type utilityModule struct {
 
 	config *configs.UtilityConfig
 
-	logger  modules.Logger
+	logger  *modules.Logger
 	mempool mempool.TXMempool
 }
 

--- a/utility/module_test.go
+++ b/utility/module_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pokt-network/pocket/logger"
 	"github.com/pokt-network/pocket/persistence"
 	"github.com/pokt-network/pocket/runtime"
 	"github.com/pokt-network/pocket/runtime/configs"
@@ -73,6 +74,7 @@ func newTestingUtilityContext(t *testing.T, height int64) *utilityContext {
 	})
 
 	uc := &utilityContext{
+		logger:             logger.Global.CreateLoggerForModule(modules.UtilityModuleName),
 		height:             height,
 		persistenceContext: persistenceContext,
 		savePointsSet:      make(map[string]struct{}),


### PR DESCRIPTION
<!-- REMOVE this comment block after following the instructions
 1. Make the title of the PR is descriptive and follows this format: `[<Module>] <DESCRIPTION>`
 2. Update the _Assigness_, _Labels_, _Projects_, _Milestone_ before submitting the PR for review.
 3. Add label(s) for the purpose (e.g. `persistence`) and, if applicable, priority (e.g. `low`) labels as well.
-->

## Description

Previously when setting up a new module according to the logger module readme, one encounters [`hugeParam` linter error](https://golangci-lint.run/usage/linters/#gocritic) about the module's `logger` field.

## Issue

![image](https://user-images.githubusercontent.com/600733/220939274-ef21a949-7362-4d95-8b02-8818db15a8bd.png)

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes


- Update the logger module interface to use logger pointers instead of values
- Update logger value references with pointers
- Update README

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [x] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
