### PR TITLE
[Tooling] Returning failed tests full output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Output test failures
         # Makes it easier to find failed tests so no need to scroll through the whole log.
         if: ${{ failure() && env.TARGET_GOLANG_VERSION == matrix.go }}
-        run: jq --argjson fail_tests "$(jq -c -r 'select(.Action == "fail") | select(.Test) | .Test' test_results.json | jq -R -s -c 'split("\n") | map(select(length>0))')" 'select(.Test as $t | ($fail_tests | arrays)[] | select($t == .))' test_results.json
+        run: jq --argjson fail_tests "$(jq -c -r 'select(.Action == "fail") | select(.Test) | .Test' test_results.json | jq -R -s -c -r 'split("\n") | map(select(length>0))')" 'select(.Test as $t | ($fail_tests | arrays)[] | select($t == .)) | select(.Output) | .Output' test_results.json | jq -r | sed ':a;N;$!ba;s/\n\n/\n/g'
       - name: Upload test results
         if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Output test failures
         # Makes it easier to find failed tests so no need to scroll through the whole log.
         if: ${{ failure() && env.TARGET_GOLANG_VERSION == matrix.go }}
-        run: cat test_results.json | jq 'select(.Action == "fail")'
+        run: jq --argjson fail_tests "$(jq -c -r 'select(.Action == "fail") | select(.Test) | .Test' test_results.json | jq -R -s -c 'split("\n") | map(select(length>0))')" 'select(.Test as $t | ($fail_tests | arrays)[] | select($t == .))' test_results.json
       - name: Upload test results
         if: ${{ always() && env.TARGET_GOLANG_VERSION == matrix.go }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

This PR updated our Github workflow to return the full output of failed tests for easier debugging/troubleshooting.

It was raised by @bryanchriswhite here:
https://github.com/pokt-network/pocket/pull/534#issuecomment-1441480145

![image](https://user-images.githubusercontent.com/29378614/220946245-07865c91-f0eb-4564-a8e9-773926c11cd7.png)


And also probably related:

![image](https://user-images.githubusercontent.com/29378614/220948460-0f80797d-dff0-4823-bb43-fa12da59e968.png)



## Issue



## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- updated `jq` 🪄 to return all the rows that match a failed test

## Testing

- [ ] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
