### PR TITLE
add get secrets perms to cluster-manager-account service account

### DIFF
--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.22] - 2023-03-08
+
+- add permissions to get private keys secret on cluster-manager-account service account
+
 ## [0.0.0.21] - 2023-03-02
 
 - added HOME environment variable to image build to fix tilt installation

--- a/build/localnet/manifests/role-bindings.yaml
+++ b/build/localnet/manifests/role-bindings.yaml
@@ -1,11 +1,14 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: debug-client-binding
+  name: private-keys-viewer-binding
   namespace: default
 subjects:
   - kind: ServiceAccount
     name: debug-client-account
+    apiGroup: ""
+  - kind: ServiceAccount
+    name: cluster-manager-account
     apiGroup: ""
 roleRef:
   kind: Role


### PR DESCRIPTION
<!-- REMOVE this comment block after following the instructions
 1. Make the title of the PR is descriptive and follows this format: `[<Module>] <DESCRIPTION>`
 2. Update the _Assigness_, _Labels_, _Projects_, _Milestone_ before submitting the PR for review.
 3. Add label(s) for the purpose (e.g. `persistence`) and, if applicable, priority (e.g. `low`) labels as well.
-->

## Description

<!-- REMOVE this comment block after following the instructions
1. Add a summary of the change including: motivation, reasons, context, dependencies, etc...
2. If applicable, specify the key files that should be looked at.
-->

Allows cluster-manager to get `v1-localnet-validators-private-keys` secret.

## Issue

Cluster manager complained about inability to access private keys secret when ran localnet from scratch.

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [x] Other <!-- add details here if it a different type of change -->

## List of changes

<!-- REMOVE this comment block after following the instructions
 List out all the changes made
-->

- add `cluster-manager-account` service account to an existing binding

## Testing

- [ ] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
