### PR TITLE
[Documentation] Fix SLIP Master Key and Child Key diagrams to be in the correct order

### DIFF
--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.39] - 2023-03-09
+
+- Fix diagrams in SLIP documentation to be in the correct order
+
 ## [0.0.0.38] - 2023-03-03
 
 - Support libp2p module in node

--- a/shared/crypto/README.md
+++ b/shared/crypto/README.md
@@ -113,6 +113,28 @@ The keys are generated using the BIP-44 path `m/44'/635'/%d'` where `%d` is the 
 Master key derivation is done as follows:
 ```mermaid
 flowchart LR
+    subgraph HMAC
+        direction TB
+        A["hmac = hmacNew(sha512, seedModifier)"]
+        B["hmac.Write(seed)"]
+        C["convertToBytes(hmac)"]
+        A-->B
+        B--hmac-->C
+    end
+    subgraph MASTER-KEY
+        direction LR
+        D["SecretKey: hmacBytes[:32]"]
+        E["ChainCode: hmacBytes[32:]"]
+        D --> KEY
+        E --> KEY
+    end
+    seed-->HMAC
+    HMAC--hmacBytes-->MASTER-KEY
+```
+
+Child keys are derived from their parents as follows:
+```mermaid
+flowchart LR
     subgraph HCHILD["HMAC-CHILD"]
         direction TB
         C["append(0x0, parent.SecretKey, bigEndian(index))"]
@@ -133,28 +155,6 @@ flowchart LR
     Index-->HCHILD
     Parent-->HCHILD
     HCHILD--hmacBytes-->CKEY
-```
-
-Child keys are derived from their parents as follows:
-```mermaid
-flowchart LR
-    subgraph HMAC
-        direction TB
-        A["hmac = hmacNew(sha512, seedModifier)"]
-        B["hmac.Write(seed)"]
-        C["convertToBytes(hmac)"]
-        A-->B
-        B--hmac-->C
-    end
-    subgraph MASTER-KEY
-        direction LR
-        D["SecretKey: hmacBytes[:32]"]
-        E["ChainCode: hmacBytes[32:]"]
-        D --> KEY
-        E --> KEY
-    end
-    seed-->HMAC
-    HMAC--hmacBytes-->MASTER-KEY
 ```
 
 <!-- GITHUB_WIKI: shared/crypto/readme -->


### PR DESCRIPTION
## Description

The Master key generation diagram and the Child key generation diagrams are in the wrong order in the SLIP documentation. This PR puts them the correct way around

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Reorder master key and child key generation diagrams

## Testing

- [ ] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
