### PR TITLE
[CLI] add private keys embed to debug cli build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,4 +518,4 @@ check_cross_module_imports: ## Lists cross-module imports
 
 .PHONY: send_local_tx
 send_local_tx: ## A hardcoded send tx to make LocalNet debugging easier
-	go run app/client/*.go Account Send --non_interactive 00104055c00bed7c983a48aac7dc6335d7c607a7 00204737d2a165ebe4be3a7d5b0af905b0ea91d8 1000
+	go run -tags=debug app/client/*.go Account Send --non_interactive 00104055c00bed7c983a48aac7dc6335d7c607a7 00204737d2a165ebe4be3a7d5b0af905b0ea91d8 1000

--- a/app/client/cli/cmd.go
+++ b/app/client/cli/cmd.go
@@ -2,11 +2,9 @@ package cli
 
 import (
 	"context"
-	"github.com/pokt-network/pocket/logger"
 	"os"
 
-	// NOTE: Imported for debug purposes in order to populate the keybase with the pre-generated keys
-	_ "github.com/pokt-network/pocket/app/client/keybase/debug"
+	"github.com/pokt-network/pocket/logger"
 	"github.com/pokt-network/pocket/runtime/defaults"
 	"github.com/spf13/cobra"
 )

--- a/app/client/debug.go
+++ b/app/client/debug.go
@@ -3,7 +3,14 @@
 package main
 
 import (
+	// Importing the "debug" package from "github.com/pokt-network/pocket/app/client/keybase/debug".
 	_ "github.com/pokt-network/pocket/app/client/keybase/debug"
 )
 
-// silence is golden
+// This file serves as a feature flag based on the build tag "debug".
+// When the build tag "debug" is present, the init() function in keystore.go is triggered via the anonymous import above.
+// This functionality is intended for debugging purposes only.
+
+// Additional debug functionality in the client CLI could be included here.
+// For example, logging or error handling utilities that are useful for developers when debugging their applications.
+// To run the client CLI with the "debug" build tag, run the following command: go run -tags=debug app/client/*.go

--- a/app/client/debug.go
+++ b/app/client/debug.go
@@ -1,0 +1,9 @@
+//go:build debug
+
+package main
+
+import (
+	_ "github.com/pokt-network/pocket/app/client/keybase/debug"
+)
+
+// silence is golden

--- a/app/client/doc/CHANGELOG.md
+++ b/app/client/doc/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.21] - 2023-03-14
+
+- Simplifies the debug CLI tooling by embedding private-keys.yaml manifest
+  into the CLI binary when the debug build tag is present.
+
 ## [0.0.0.20] - 2023-03-03
 
 - Support libp2p module in debug CLI

--- a/app/client/doc/README.md
+++ b/app/client/doc/README.md
@@ -4,6 +4,8 @@ The CLI is meant to be an user but also a machine friendly way for interacting w
 
 The spirit of the documentation is to continuously update and inform the reader of the general scope of the node binary as breaking, rapid development occurs.
 
+There are two modes of operating the CLI. Standard and Debug. Standard is the default mode and is meant for users to interact with the network. Debug is meant for developers to interact with the network and debug issues. To enter debug mode, the CLI must be built with the `debug` build tag.
+
 ## Commands
 
 Command tree available [here](./commands/client.md)

--- a/app/client/keybase/debug/keystore.go
+++ b/app/client/keybase/debug/keystore.go
@@ -1,31 +1,27 @@
+//go:build debug
+
 package debug
 
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	r "runtime"
+	"sync"
 
 	"github.com/pokt-network/pocket/app/client/keybase"
+	"github.com/pokt-network/pocket/build"
 	"github.com/pokt-network/pocket/logger"
-	"github.com/pokt-network/pocket/runtime"
 	cryptoPocket "github.com/pokt-network/pocket/shared/crypto"
-	pocketk8s "github.com/pokt-network/pocket/shared/k8s"
-	"github.com/pokt-network/pocket/shared/utils"
 	"gopkg.in/yaml.v2"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 const (
 	// NOTE: This is the number of validators in the private-keys.yaml manifest file
-	numValidators       = 999
-	debugKeybaseSuffix  = "/.pocket/keys"
-	privateKeysYamlFile = "../../../../../build/localnet/manifests/private-keys.yaml"
+	numValidators      = 999
+	debugKeybaseSuffix = "/.pocket/keys"
 )
 
 var (
-	// TODO: Allow users to override this value via `datadir` flag
+	// TODO: Allow users to override this value via `datadir` flag or env var or config file
 	debugKeybasePath string
 )
 
@@ -49,11 +45,8 @@ func initializeDebugKeybase() error {
 		err                  error
 	)
 
-	if runtime.IsProcessRunningInsideKubernetes() {
-		validatorKeysPairMap, err = fetchValidatorPrivateKeysFromK8S()
-	} else {
-		validatorKeysPairMap, err = fetchValidatorPrivateKeysFromFile()
-	}
+	validatorKeysPairMap, err = fetchValidatorPrivateKeysFromYaml()
+
 	if err != nil {
 		return err
 	}
@@ -73,28 +66,55 @@ func initializeDebugKeybase() error {
 
 	// Add validator addresses if not present
 	if len(curAddr) < numValidators {
-		fmt.Println("Rehydrating keybase from private-keys.yaml ...")
+		logger.Global.Debug().Msgf(fmt.Sprintf("Debug keybase initializing... Adding %d validator keys to the keybase", numValidators-len(curAddr)))
+
 		// Use writebatch to speed up bulk insert
 		wb := db.NewWriteBatch()
+
+		// Create a channel to receive errors from goroutines
+		errCh := make(chan error, numValidators)
+
+		// Create a WaitGroup to wait for all goroutines to finish
+		var wg sync.WaitGroup
+		wg.Add(numValidators)
+
 		for _, privHexString := range validatorKeysPairMap {
-			// Import the keys into the keybase with no passphrase or hint as these are for debug purposes
-			keyPair, err := cryptoPocket.CreateNewKeyFromString(privHexString, "", "")
-			if err != nil {
-				return err
-			}
+			go func(privHexString string) {
+				defer wg.Done()
 
-			// Use key address as key in DB
-			addrKey := keyPair.GetAddressBytes()
+				// Import the keys into the keybase with no passphrase or hint as these are for debug purposes
+				keyPair, err := cryptoPocket.CreateNewKeyFromString(privHexString, "", "")
+				if err != nil {
+					errCh <- err
+					return
+				}
 
-			// Encode KeyPair into []byte for value
-			keypairBz, err := keyPair.Marshal()
-			if err != nil {
-				return err
-			}
-			if err := wb.Set(addrKey, keypairBz); err != nil {
-				return err
-			}
+				// Use key address as key in DB
+				addrKey := keyPair.GetAddressBytes()
+
+				// Encode KeyPair into []byte for value
+				keypairBz, err := keyPair.Marshal()
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if err := wb.Set(addrKey, keypairBz); err != nil {
+					errCh <- err
+					return
+				}
+			}(privHexString)
 		}
+
+		// Wait for all goroutines to finish
+		wg.Wait()
+
+		// Check if any goroutines returned an error
+		select {
+		case err := <-errCh:
+			return err
+		default:
+		}
+
 		if err := wb.Flush(); err != nil {
 			return err
 		}
@@ -108,40 +128,10 @@ func initializeDebugKeybase() error {
 	return nil
 }
 
-func fetchValidatorPrivateKeysFromK8S() (map[string]string, error) {
-	// Initialize Kubernetes client
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize Kubernetes config: %w", err)
-	}
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize Kubernetes client: %w", err)
-	}
-
-	// Fetch validator private keys from Kubernetes
-	validatorKeysPairMap, err := pocketk8s.FetchValidatorPrivateKeys(clientset)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch validator private keys from Kubernetes: %w", err)
-	}
-	return validatorKeysPairMap, nil
-}
-
-func fetchValidatorPrivateKeysFromFile() (map[string]string, error) {
-	// BUG: When running the CLI using the build binary (i.e. `p1`), it searched for the private-keys.yaml file in `github.com/pokt-network/pocket/build/localnet/manifests/private-keys.yaml`
-	// Get private keys from manifest file
-	_, current, _, _ := r.Caller(0)
-	//nolint:gocritic // Use path to find private-keys yaml file from being called in any location in the repo
-	yamlFile := filepath.Join(current, privateKeysYamlFile)
-	if exists, err := utils.FileExists(yamlFile); !exists || err != nil {
-		return nil, fmt.Errorf("unable to find YAML file: %s", yamlFile)
-	}
+// fetchValidatorPrivateKeysFromYaml fetches the validator private keys from the private-keys.yaml manifest file.
+func fetchValidatorPrivateKeysFromYaml() (map[string]string, error) {
 
 	// Parse the YAML file and load into the config struct
-	yamlData, err := os.ReadFile(yamlFile)
-	if err != nil {
-		return nil, err
-	}
 	var config struct {
 		ApiVersion string            `yaml:"apiVersion"`
 		Kind       string            `yaml:"kind"`
@@ -149,7 +139,7 @@ func fetchValidatorPrivateKeysFromFile() (map[string]string, error) {
 		Type       string            `yaml:"type"`
 		StringData map[string]string `yaml:"stringData"`
 	}
-	if err := yaml.Unmarshal(yamlData, &config); err != nil {
+	if err := yaml.Unmarshal(build.PrivateKeysFile, &config); err != nil {
 		return nil, err
 	}
 	validatorKeysMap := make(map[string]string)

--- a/app/client/keybase/debug/keystore.go
+++ b/app/client/keybase/debug/keystore.go
@@ -45,7 +45,7 @@ func initializeDebugKeybase() error {
 		err                  error
 	)
 
-	validatorKeysPairMap, err = fetchValidatorPrivateKeysFromYaml()
+	validatorKeysPairMap, err = parseValidatorPrivateKeysFromEmbeddedYaml()
 
 	if err != nil {
 		return err
@@ -128,8 +128,8 @@ func initializeDebugKeybase() error {
 	return nil
 }
 
-// fetchValidatorPrivateKeysFromYaml fetches the validator private keys from the private-keys.yaml manifest file.
-func fetchValidatorPrivateKeysFromYaml() (map[string]string, error) {
+// parseValidatorPrivateKeysFromEmbeddedYaml fetches the validator private keys from the embedded build/localnet/manifests/private-keys.yaml manifest file.
+func parseValidatorPrivateKeysFromEmbeddedYaml() (map[string]string, error) {
 
 	// Parse the YAML file and load into the config struct
 	var config struct {

--- a/app/docs/CHANGELOG.md
+++ b/app/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.2] - 2023-03-14
+
+- Simplifies the debug CLI tooling by embedding private-keys.yaml manifest
+  into the CLI binary when the debug build tag is present.
+
 ## [0.0.0.1] - 2023-02-21
 
 - Rename ServiceNode Actor Type Name to Servicer

--- a/build/debug.go
+++ b/build/debug.go
@@ -1,0 +1,16 @@
+//go:build debug
+
+package build
+
+import _ "embed"
+
+// PrivateKeysFile is the pre-generated manifest file for LocalNet debugging
+//
+//go:embed localnet/manifests/private-keys.yaml
+var PrivateKeysFile []byte
+
+func init() {
+	if len(PrivateKeysFile) == 0 {
+		panic("PrivateKeysFile is empty")
+	}
+}

--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.23] - 2023-03-14
+
+- Simplifies the debug CLI tooling by embedding private-keys.yaml manifest
+  into the CLI binary when the debug build tag is present.
+
 ## [0.0.0.22] - 2023-03-08
 
 - add permissions to get private keys secret on cluster-manager-account service account

--- a/build/dummy.go
+++ b/build/dummy.go
@@ -1,0 +1,8 @@
+//go:build !debug
+
+// build dummy exists to prevent the gopls from complaining about an empty package without extra configuration. This
+// dummy is included when the debug build tag is not included.
+package build
+
+// PrivateKeysFile is the pre-generated manifest file for LocalNet debugging
+var PrivateKeysFile []byte

--- a/build/localnet/Tiltfile
+++ b/build/localnet/Tiltfile
@@ -28,6 +28,7 @@ if (localnet_config_file != localnet_config) or (
 deps = [
     "app",
     "build/localnet",
+    "build/debug.go",
     "consensus",
     "p2p",
     "persistance",


### PR DESCRIPTION
## Description

SImplifies the debug CLI tooling by embedding private-keys.yaml manifest into the CLI binary when the `debug` build tag is present. It removes some code from the debug keybase that detected if the CLI was running in kubernetes and would source the debug private keys from a configmap secret.

## Issue

Fixes https://github.com/pokt-network/pocket/issues/525

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [x] Other <!-- add details here if it a different type of change -->

## List of changes

See description.

## Testing

- [x] `make develop_test`
- [x] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
