### PR TITLE
[Documentation] Fix links to RPC module docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you'd like to contribute to the Pocket V1 Protocol, start by:
 - [Persistence Architecture](persistence/docs/README.md)
 - [P2P Architecture](p2p/README.md)
 - [APP Architecture](app/client/doc/README.md)
-- [RPC Architecture](app/pocket/rpc/doc/README.md)
+- [RPC Architecture](rpc/doc/README.md)
 - [Node binary Architecture](app/pocket/doc/README.md)
 
 ### Changelogs
@@ -55,7 +55,7 @@ If you'd like to contribute to the Pocket V1 Protocol, start by:
 - [Persistence Changelog](persistence/docs/CHANGELOG.md)
 - [P2P Changelog](p2p/CHANGELOG.md)
 - [APP Changelog](app/client/doc/CHANGELOG.md)
-- [RPC Changelog](app/pocket/rpc/doc/CHANGELOG.md)
+- [RPC Changelog](rpc/doc/CHANGELOG.md)
 - [Node binary Changelog](app/pocket/doc/CHANGELOG.md)
 
 - _Coming Soon: Telemetry Changelog_


### PR DESCRIPTION
## Description

Fix the links to RPC module Readme and Changelog in the main README.md file

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Fix links to RPC module docs

## Testing

- [ ] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
