### PR TITLE
[P2P, Libp2p] fix: IPv6 conversion to valid URL

### DIFF
--- a/libp2p/docs/CHANGELOG.md
+++ b/libp2p/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.7] - 2023-03-23
+
+- Wrap IPv6 address in square brackets as per RFC3986 §3.2.2
+
 ## [0.0.0.6] - 2023-03-22
 
 - Improve URL validation and error handling in Libp2pMultiaddrFromServiceURL function

--- a/libp2p/network/url_conversion.go
+++ b/libp2p/network/url_conversion.go
@@ -113,8 +113,10 @@ func ServiceURLFromLibp2pMultiaddr(addr multiaddr.Multiaddr) (string, error) {
 
 	// Top level protocol must be a network protocol (e.g. ip4, ip6).
 	switch networkProtocol.Code {
-	case multiaddr.P_IP4, multiaddr.P_IP6:
+	case multiaddr.P_IP4:
 		return fmt.Sprintf("%s:%s", networkValue, transportValue), nil
+	case multiaddr.P_IP6:
+		return fmt.Sprintf("[%s]:%s", networkValue, transportValue), nil
 	}
 
 	return "", fmt.Errorf(

--- a/libp2p/network/url_conversion_test.go
+++ b/libp2p/network/url_conversion_test.go
@@ -144,18 +144,18 @@ func TestServiceURLFromLibp2pMultiaddr_Success(t *testing.T) {
 		{
 			"IPv6 full",
 			"/ip6/2a00:1450:4005:0802:0000:0000:0000:2004/tcp/8080",
-			"2a00:1450:4005:802::2004:8080",
+			"[2a00:1450:4005:802::2004]:8080",
 		},
 		{
 			"IPv6 short",
 			"/ip6/2a00:1450:4005:802::2004/tcp/8080",
-			"2a00:1450:4005:802::2004:8080",
+			"[2a00:1450:4005:802::2004]:8080",
 		},
 		{
 			"IPv6 shorter",
 			// NB: this address is not equivalent to those above.
 			"/ip6/2a00::2004/tcp/8080",
-			"2a00::2004:8080",
+			"[2a00::2004]:8080",
 		},
 	}
 


### PR DESCRIPTION

## Description

Fixes URL conversion utility returning invalid IPv6 URLs. Thanks again @0xBigBoss for the reminder about IPv6 URL formatting. :raised_hands: 

## Issue

Related to but missing from #597 

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Wrap IPv6 address in square brackets as per [RFC3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2)

## Testing

- [x] `make develop_test`
- [ ] [LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md) w/ all of the steps outlined in the `README`

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
