### PR TITLE
[CONSENSUS] bugfix for: unable to send txs in localnet - Issue #631

### DIFF
--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.40] - 2023-03-29
+
+- Bugfix for (unable to send txs in localnet) #631
+
 ## [0.0.0.39] - 2023-03-26
 
 - Refactored `utilityContext` into `utilityUnitOfWork`

--- a/consensus/hotstuff_leader.go
+++ b/consensus/hotstuff_leader.go
@@ -75,13 +75,12 @@ func (handler *HotstuffLeaderMessageHandler) HandleNewRoundMessage(m *consensusM
 	} else {
 		// Leader acts like a replica if `prepareQC` is not `nil`
 		// TODO: Do we need to call `validateProposal` here similar to how replicas does it
+		if err := m.applyBlock(highPrepareQC.Block); err != nil {
+			m.logger.Error().Err(err).Msg(typesCons.ErrApplyBlock.Error())
+			m.paceMaker.InterruptRound("failed to apply block")
+			return
+		}
 		m.block = highPrepareQC.Block
-	}
-
-	if err := m.applyBlock(m.block); err != nil {
-		m.logger.Error().Err(err).Msg(typesCons.ErrApplyBlock.Error())
-		m.paceMaker.InterruptRound("failed to apply block")
-		return
 	}
 
 	m.step = Prepare


### PR DESCRIPTION
## Description

This PR addresses the bug reported in #631 

## Issue

Fixes #631

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- The apply logic was running indiscriminately and it has to run only if the leader is not preparing a new block

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
