### PR TITLE
[Documentation] Swap validator and non-validator triggers when finished synching

### DIFF
--- a/state_machine/docs/CHANGELOG.md
+++ b/state_machine/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.4] - 2023-04-03
+
+- Clarify state transitions in README
+
 ## [0.0.0.3] - 2023-04-03
 
 - Update state machine states: `Stopped`, `P2P_Bootstrapping`, `P2P_Bootstrapped`, `Consensus_Unsynced`, `Consensus_SyncMode`, `Consensus_Synced`, `Consensus_Pacemaker`.

--- a/state_machine/docs/README.md
+++ b/state_machine/docs/README.md
@@ -68,8 +68,8 @@ These are the main building blocks:
 - **Consensus_Unsynced**: Node is out of sync, the Consensus module sends `Consensus_IsSyncing` event -> transitions to `Consensus_SyncMode` to start syncing with the rest of the network.
 - **Consensus_SyncMode**: The Consensus module runs `StartSyncing()` and requests blocks one by one from peers in its address book.
 - **Node finishes syncing**: When node completes syncing:
-  - if the node is a validator, the Consensus module sends `Consensus_IsSynchedValidator` event -> transitions to `Consensus_Synched`.
-  - if the node is not a validator, the Consensus module sends `Consensus_IsSynchedNonValidator` event -> transitions to `Consensus_Pacemaker`.
+  - if the node is a validator, the Consensus module sends `Consensus_IsSynchedValidator` event -> transitions to `Consensus_Pacemaker`.
+  - if the node is not a validator, the Consensus module sends `Consensus_IsSynchedNonValidator` event -> transitions to `Consensus_Synched`.
 - **Consensus_Pacemaker**: Node participates in the block generation process. If node receives a block proposal with height higher than its current height, the Consensus Module sends `Consensus_IsUnsynced` event -> transitions to `Consensus_Unsynced`.
 - **Consensus_Synched**: Currently, the Consensus module never sends `Consensus_IsSynchedValidator` event, and non-validator node always stays in `Consensus_SyncMode`.
 


### PR DESCRIPTION
## Description

Clarify that the `validators` instead of the `non-validators` enter `Consensus_Pacemaker` mode once they finish syncing in the state machine README file

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Clarify documentation

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
