### PR TITLE
[Persistence][Utility] Pools Address hack removal + state accessor fix for params and flags

### DIFF
--- a/build/config/genesis.json
+++ b/build/config/genesis.json
@@ -4011,27 +4011,27 @@
   ],
   "pools": [
     {
-      "address": "DAO",
+      "address": "44414f0000000000000000000000000000000000",
       "amount": "100000000000000"
     },
     {
-      "address": "FeeCollector",
+      "address": "466565436f6c6c6563746f720000000000000000",
       "amount": "0"
     },
     {
-      "address": "AppStakePool",
+      "address": "4170705374616b65506f6f6c0000000000000000",
       "amount": "100000000000000"
     },
     {
-      "address": "ValidatorStakePool",
+      "address": "56616c696461746f725374616b65506f6f6c0000",
       "amount": "100000000000000"
     },
     {
-      "address": "ServicerStakePool",
+      "address": "53657276696365725374616b65506f6f6c000000",
       "amount": "100000000000000"
     },
     {
-      "address": "FishermanStakePool",
+      "address": "4669736865726d616e5374616b65506f6f6c0000",
       "amount": "100000000000000"
     }
   ],

--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.31] - 2023-04-06
+
+- Updated `genesis.json` and `configs.yaml` to reflect pools address changes
+
 ## [0.0.0.30] - 2023-03-31
 
 - Improve LocalNet documentation by adding a TLDR commands to provision LocalNet with `kind`.

--- a/build/localnet/manifests/configs.yaml
+++ b/build/localnet/manifests/configs.yaml
@@ -4074,27 +4074,27 @@ data:
       ],
       "pools": [
         {
-          "address": "DAO",
+          "address": "44414f0000000000000000000000000000000000",
           "amount": "100000000000000"
         },
         {
-          "address": "FeeCollector",
+          "address": "466565436f6c6c6563746f720000000000000000",
           "amount": "0"
         },
         {
-          "address": "AppStakePool",
+          "address": "4170705374616b65506f6f6c0000000000000000",
           "amount": "100000000000000"
         },
         {
-          "address": "ValidatorStakePool",
+          "address": "56616c696461746f725374616b65506f6f6c0000",
           "amount": "100000000000000"
         },
         {
-          "address": "ServicerStakePool",
+          "address": "53657276696365725374616b65506f6f6c000000",
           "amount": "100000000000000"
         },
         {
-          "address": "FishermanStakePool",
+          "address": "4669736865726d616e5374616b65506f6f6c0000",
           "amount": "100000000000000"
         }
       ],

--- a/persistence/account.go
+++ b/persistence/account.go
@@ -41,30 +41,30 @@ func (p *PostgresContext) GetAccountsUpdated(height int64) (accounts []*coreType
 
 // --- Pool Functions ---
 
-func (p *PostgresContext) InsertPool(name, amount string) error {
-	return p.insertAccount(types.Pool, name, amount)
+func (p *PostgresContext) InsertPool(address []byte, amount string) error {
+	return p.insertAccount(types.Pool, hex.EncodeToString(address), amount)
 }
 
-func (p *PostgresContext) GetPoolAmount(name string, height int64) (amount string, err error) {
-	return p.getAccountAmount(types.Pool, name, height)
+func (p *PostgresContext) GetPoolAmount(address []byte, height int64) (amount string, err error) {
+	return p.getAccountAmount(types.Pool, hex.EncodeToString(address), height)
 }
 
-func (p *PostgresContext) AddPoolAmount(name, amount string) error {
-	return p.operationAccountAmount(types.Pool, name, amount, func(orig, delta *big.Int) error {
+func (p *PostgresContext) AddPoolAmount(address []byte, amount string) error {
+	return p.operationAccountAmount(types.Pool, hex.EncodeToString(address), amount, func(orig, delta *big.Int) error {
 		orig.Add(orig, delta)
 		return nil
 	})
 }
 
-func (p *PostgresContext) SubtractPoolAmount(name, amount string) error {
-	return p.operationAccountAmount(types.Pool, name, amount, func(orig, delta *big.Int) error {
+func (p *PostgresContext) SubtractPoolAmount(address []byte, amount string) error {
+	return p.operationAccountAmount(types.Pool, hex.EncodeToString(address), amount, func(orig, delta *big.Int) error {
 		orig.Sub(orig, delta)
 		return nil
 	})
 }
 
-func (p *PostgresContext) SetPoolAmount(name, amount string) error {
-	return p.operationAccountAmount(types.Pool, name, amount, func(orig, amount *big.Int) error {
+func (p *PostgresContext) SetPoolAmount(address []byte, amount string) error {
+	return p.operationAccountAmount(types.Pool, hex.EncodeToString(address), amount, func(orig, amount *big.Int) error {
 		orig.Set(amount)
 		return nil
 	})

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.43] - 2023-04-06
+
+- Fixed flag/params keying
+- Updated pools read/write functions to use a real address, not a string that is named address and obviously is not hexadecimal
+- Updated tests
+
 ## [0.0.0.42] - 2023-03-30
 
 - Replaced all `pgx.Conn` with `pgxpool.Conn` to use postgres connection pooling

--- a/persistence/genesis.go
+++ b/persistence/genesis.go
@@ -16,15 +16,16 @@ func (m *persistenceModule) populateGenesisState(state *genesis.GenesisState) {
 	// REFACTOR: This business logic should probably live in `types/genesis.go`
 	//           and we need to add proper unit tests for it.`
 	poolValues := make(map[string]*big.Int, 0)
-	addValueToPool := func(poolName string, valueToAdd string) error {
+	addValueToPool := func(address []byte, valueToAdd string) error {
 		value, err := utils.StringToBigInt(valueToAdd)
 		if err != nil {
 			return err
 		}
-		if present := poolValues[poolName]; present == nil {
-			poolValues[poolName] = big.NewInt(0)
+		strAddr := hex.EncodeToString(address)
+		if present := poolValues[strAddr]; present == nil {
+			poolValues[strAddr] = big.NewInt(0)
 		}
-		poolValues[poolName].Add(poolValues[poolName], value)
+		poolValues[strAddr].Add(poolValues[strAddr], value)
 		return nil
 	}
 
@@ -45,12 +46,11 @@ func (m *persistenceModule) populateGenesisState(state *genesis.GenesisState) {
 		}
 	}
 	for _, pool := range state.GetPools() {
-		// addrBz, err := hex.DecodeString(pool.GetAddress())
-		// if err != nil {
-		// 	m.logger.Fatal().Err(err).Str("address", pool.GetAddress()).Msg("an error occurred converting address to bytes")
-		// }
-		// err = rwCtx.InsertPool(hex.EncodeToString(addrBz), pool.GetAmount())
-		err = rwCtx.InsertPool(pool.GetAddress(), pool.GetAmount())
+		addrBz, err := hex.DecodeString(pool.GetAddress())
+		if err != nil {
+			m.logger.Fatal().Err(err).Str("address", pool.GetAddress()).Msg("an error occurred converting address to bytes")
+		}
+		err = rwCtx.InsertPool(addrBz, pool.GetAmount())
 		if err != nil {
 			m.logger.Fatal().Err(err).Str("address", pool.GetAddress()).Msg("an error occurred inserting an pool in the genesis state")
 		}

--- a/persistence/genesis.go
+++ b/persistence/genesis.go
@@ -45,6 +45,11 @@ func (m *persistenceModule) populateGenesisState(state *genesis.GenesisState) {
 		}
 	}
 	for _, pool := range state.GetPools() {
+		// addrBz, err := hex.DecodeString(pool.GetAddress())
+		// if err != nil {
+		// 	m.logger.Fatal().Err(err).Str("address", pool.GetAddress()).Msg("an error occurred converting address to bytes")
+		// }
+		// err = rwCtx.InsertPool(hex.EncodeToString(addrBz), pool.GetAmount())
 		err = rwCtx.InsertPool(pool.GetAddress(), pool.GetAmount())
 		if err != nil {
 			m.logger.Fatal().Err(err).Str("address", pool.GetAddress()).Msg("an error occurred inserting an pool in the genesis state")
@@ -105,7 +110,7 @@ func (m *persistenceModule) populateGenesisState(state *genesis.GenesisState) {
 			if err != nil {
 				log.Fatalf("an error occurred inserting an %s in the genesis state: %s", saic.Name, err.Error())
 			}
-			if err = addValueToPool(saic.Pool.FriendlyName(), act.GetStakedAmount()); err != nil {
+			if err = addValueToPool(saic.Pool.Address(), act.GetStakedAmount()); err != nil {
 				log.Fatalf("an error occurred inserting staked tokens into %s pool: %s", saic.Pool, err.Error())
 			}
 		}

--- a/persistence/genesis.go
+++ b/persistence/genesis.go
@@ -45,7 +45,7 @@ func (m *persistenceModule) populateGenesisState(state *genesis.GenesisState) {
 		}
 	}
 	for _, pool := range state.GetPools() {
-		err = rwCtx.InsertPool(pool.GetAddress(), pool.GetAmount()) // pool.GetAddress() returns the pool's semantic name
+		err = rwCtx.InsertPool(pool.GetAddress(), pool.GetAmount())
 		if err != nil {
 			m.logger.Fatal().Err(err).Str("address", pool.GetAddress()).Msg("an error occurred inserting an pool in the genesis state")
 		}

--- a/persistence/state.go
+++ b/persistence/state.go
@@ -284,7 +284,11 @@ func (p *PostgresContext) updatePoolTrees() error {
 	}
 
 	for _, pool := range pools {
-		bzAddr := []byte(pool.GetAddress())
+		bzAddr, err := hex.DecodeString(pool.GetAddress())
+		if err != nil {
+			return err
+		}
+
 		accBz, err := codec.GetCodec().Marshal(pool)
 		if err != nil {
 			return err

--- a/persistence/state.go
+++ b/persistence/state.go
@@ -331,7 +331,7 @@ func (p *PostgresContext) updateParamsTree() error {
 
 	for _, param := range params {
 		paramBz, err := codec.GetCodec().Marshal(param)
-		paramKey := crypto.SHA3Hash(paramBz)
+		paramKey := crypto.SHA3Hash([]byte(param.Name))
 		if err != nil {
 			return err
 		}
@@ -351,7 +351,7 @@ func (p *PostgresContext) updateFlagsTree() error {
 
 	for _, flag := range flags {
 		flagBz, err := codec.GetCodec().Marshal(flag)
-		flagKey := crypto.SHA3Hash(flagBz)
+		flagKey := crypto.SHA3Hash([]byte(flag.Name))
 		if err != nil {
 			return err
 		}

--- a/persistence/state.go
+++ b/persistence/state.go
@@ -136,34 +136,34 @@ func (p *PostgresContext) updateMerkleTrees() (string, error) {
 		case appMerkleTree, valMerkleTree, fishMerkleTree, servicerMerkleTree:
 			actorType, ok := merkleTreeToActorTypeName[treeType]
 			if !ok {
-				return "", fmt.Errorf("no actor type found for merkle tree: %v\n", treeType)
+				return "", fmt.Errorf("no actor type found for merkle tree: %v", treeType)
 			}
 			if err := p.updateActorsTree(actorType); err != nil {
-				return "", err
+				return "", fmt.Errorf("failed to update actors tree for treeType: %v, actorType: %v - %w", treeType, actorType, err)
 			}
 
 		// Account Merkle Trees
 		case accountMerkleTree:
 			if err := p.updateAccountTrees(); err != nil {
-				return "", err
+				return "", fmt.Errorf("failed to update account trees - %w", err)
 			}
 		case poolMerkleTree:
 			if err := p.updatePoolTrees(); err != nil {
-				return "", err
+				return "", fmt.Errorf("failed to update pool trees - %w", err)
 			}
 
 		// Data Merkle Trees
 		case transactionsMerkleTree:
 			if err := p.updateTransactionsTree(); err != nil {
-				return "", err
+				return "", fmt.Errorf("failed to update transactions tree - %w", err)
 			}
 		case paramsMerkleTree:
 			if err := p.updateParamsTree(); err != nil {
-				return "", err
+				return "", fmt.Errorf("failed to update params tree - %w", err)
 			}
 		case flagsMerkleTree:
 			if err := p.updateFlagsTree(); err != nil {
-				return "", err
+				return "", fmt.Errorf("failed to update flags tree - %w", err)
 			}
 
 		// Default

--- a/persistence/test/account_test.go
+++ b/persistence/test/account_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/pokt-network/pocket/persistence"
+	"github.com/pokt-network/pocket/runtime/test_artifacts/keygen"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
 	"github.com/pokt-network/pocket/shared/crypto"
 	"github.com/pokt-network/pocket/shared/utils"
@@ -220,7 +221,10 @@ func FuzzPoolAmount(f *testing.F) {
 	numOperationTypes := len(operations)
 
 	pool := newTestPool(nil)
-	err := db.SetPoolAmount(pool.Address, DefaultAccountAmount)
+	addrBz, err := hex.DecodeString(pool.Address)
+	require.NoError(f, err)
+
+	err = db.SetPoolAmount(addrBz, DefaultAccountAmount)
 	require.NoError(f, err)
 	expectedAmount := big.NewInt(DefaultAccountBig.Int64())
 
@@ -235,29 +239,29 @@ func FuzzPoolAmount(f *testing.F) {
 
 		switch op {
 		case "AddAmount":
-			originalAmountBig, err := db.GetPoolAmount(pool.Address, db.Height)
+			originalAmountBig, err := db.GetPoolAmount(addrBz, db.Height)
 			require.NoError(t, err)
 
 			originalAmount, err := utils.StringToBigInt(originalAmountBig)
 			require.NoError(t, err)
 
-			err = db.AddPoolAmount(pool.Address, deltaString)
+			err = db.AddPoolAmount(addrBz, deltaString)
 			require.NoError(t, err)
 
 			expectedAmount.Add(originalAmount, delta)
 		case "SubAmount":
-			originalAmountBig, err := db.GetPoolAmount(pool.Address, db.Height)
+			originalAmountBig, err := db.GetPoolAmount(addrBz, db.Height)
 			require.NoError(t, err)
 
 			originalAmount, err := utils.StringToBigInt(originalAmountBig)
 			require.NoError(t, err)
 
-			err = db.SubtractPoolAmount(pool.Address, deltaString)
+			err = db.SubtractPoolAmount(addrBz, deltaString)
 			require.NoError(t, err)
 
 			expectedAmount.Sub(originalAmount, delta)
 		case "SetAmount":
-			err := db.SetPoolAmount(pool.Address, deltaString)
+			err := db.SetPoolAmount(addrBz, deltaString)
 			require.NoError(t, err)
 
 			expectedAmount = delta
@@ -267,7 +271,7 @@ func FuzzPoolAmount(f *testing.F) {
 			t.Errorf("Unexpected operation fuzzing operation %s", op)
 		}
 
-		currentAmount, err := db.GetPoolAmount(pool.Address, db.Height)
+		currentAmount, err := db.GetPoolAmount(addrBz, db.Height)
 		require.NoError(t, err)
 		require.Equal(t, utils.BigIntToString(expectedAmount), currentAmount, fmt.Sprintf("unexpected amount after %s", op))
 	})
@@ -275,8 +279,11 @@ func FuzzPoolAmount(f *testing.F) {
 
 func TestDefaultNonExistentPoolAmount(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
+	_, _, poolAddr := keygen.GetInstance().Next()
+	addrBz, err := hex.DecodeString(poolAddr)
+	require.NoError(t, err)
 
-	poolAmount, err := db.GetPoolAmount("some_pool_name", db.Height)
+	poolAmount, err := db.GetPoolAmount(addrBz, db.Height)
 	require.NoError(t, err)
 	require.Equal(t, "0", poolAmount)
 }
@@ -285,17 +292,19 @@ func TestSetPoolAmount(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
 	pool := newTestPool(t)
 
-	err := db.SetPoolAmount(pool.Address, DefaultStake)
+	addrBz, err := hex.DecodeString(pool.Address)
+	require.NoError(t, err)
+	err = db.SetPoolAmount(addrBz, DefaultStake)
 	require.NoError(t, err)
 
-	poolAmount, err := db.GetPoolAmount(pool.Address, db.Height)
+	poolAmount, err := db.GetPoolAmount(addrBz, db.Height)
 	require.NoError(t, err)
 	require.Equal(t, DefaultStake, poolAmount, "unexpected amount")
 
-	err = db.SetPoolAmount(pool.Address, StakeToUpdate)
+	err = db.SetPoolAmount(addrBz, StakeToUpdate)
 	require.NoError(t, err)
 
-	poolAmount, err = db.GetPoolAmount(pool.Address, db.Height)
+	poolAmount, err = db.GetPoolAmount(addrBz, db.Height)
 	require.NoError(t, err)
 	require.Equal(t, StakeToUpdate, poolAmount, "unexpected amount after second set")
 }
@@ -304,14 +313,16 @@ func TestAddPoolAmount(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
 	pool := newTestPool(t)
 
-	err := db.SetPoolAmount(pool.Address, DefaultStake)
+	addrBz, err := hex.DecodeString(pool.Address)
+	require.NoError(t, err)
+	err = db.SetPoolAmount(addrBz, DefaultStake)
 	require.NoError(t, err)
 
 	amountToAddBig := big.NewInt(100)
-	err = db.AddPoolAmount(pool.Address, utils.BigIntToString(amountToAddBig))
+	err = db.AddPoolAmount(addrBz, utils.BigIntToString(amountToAddBig))
 	require.NoError(t, err)
 
-	poolAmount, err := db.GetPoolAmount(pool.Address, db.Height)
+	poolAmount, err := db.GetPoolAmount(addrBz, db.Height)
 	require.NoError(t, err)
 
 	poolAmountBig := (&big.Int{}).Add(DefaultStakeBig, amountToAddBig)
@@ -323,14 +334,17 @@ func TestAddPoolAmount(t *testing.T) {
 func TestSubPoolAmount(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
 	pool := newTestPool(t)
-	err := db.SetPoolAmount(pool.Address, DefaultStake)
+
+	addrBz, err := hex.DecodeString(pool.Address)
+	require.NoError(t, err)
+	err = db.SetPoolAmount(addrBz, DefaultStake)
 	require.NoError(t, err)
 
 	amountToSubBig := big.NewInt(100)
-	err = db.SubtractPoolAmount(pool.Address, utils.BigIntToString(amountToSubBig))
+	err = db.SubtractPoolAmount(addrBz, utils.BigIntToString(amountToSubBig))
 	require.NoError(t, err)
 
-	poolAmount, err := db.GetPoolAmount(pool.Address, db.Height)
+	poolAmount, err := db.GetPoolAmount(addrBz, db.Height)
 	require.NoError(t, err)
 
 	poolAmountBig := (&big.Int{}).Sub(DefaultStakeBig, amountToSubBig)
@@ -355,7 +369,9 @@ func TestGetAllPools(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
 
 	updatePool := func(db *persistence.PostgresContext, pool *coreTypes.Account) error {
-		return db.AddPoolAmount(pool.GetAddress(), "10")
+		addrBz, err := hex.DecodeString(pool.Address)
+		require.NoError(t, err)
+		return db.AddPoolAmount(addrBz, "10")
 	}
 
 	// -1 because we don't count the "unspecified" pool (Pools_POOLS_UNSPECIFIED)
@@ -365,7 +381,7 @@ func TestGetAllPools(t *testing.T) {
 
 func TestPoolsUpdatedAtHeight(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
-	numPoolsInTestGenesis := 7
+	numPoolsInTestGenesis := len(coreTypes.Pools_value) - 1 // -1 because we don't count the "unspecified" pool (Pools_POOLS_UNSPECIFIED
 
 	// Check num Pools in genesis
 	accs, err := db.GetPoolsUpdated(0)
@@ -424,7 +440,8 @@ func createAndInsertNewAccount(db *persistence.PostgresContext) (*coreTypes.Acco
 
 func createAndInsertNewPool(db *persistence.PostgresContext) (*coreTypes.Account, error) {
 	pool := newTestPool(nil)
-	return &pool, db.SetPoolAmount(pool.Address, DefaultAccountAmount)
+	addrBz, _ := hex.DecodeString(pool.Address)
+	return &pool, db.SetPoolAmount(addrBz, DefaultAccountAmount)
 }
 
 // TODO(olshansky): consolidate newTestAccount and newTestPool into one function

--- a/persistence/test/account_test.go
+++ b/persistence/test/account_test.go
@@ -358,7 +358,9 @@ func TestGetAllPools(t *testing.T) {
 		return db.AddPoolAmount(pool.GetAddress(), "10")
 	}
 
-	getAllActorsTest(t, db, db.GetAllPools, createAndInsertNewPool, updatePool, 7)
+	// -1 because we don't count the "unspecified" pool (Pools_POOLS_UNSPECIFIED)
+	initialCount := len(coreTypes.Pools_value) - 1
+	getAllActorsTest(t, db, db.GetAllPools, createAndInsertNewPool, updatePool, initialCount)
 }
 
 func TestPoolsUpdatedAtHeight(t *testing.T) {

--- a/persistence/test/account_test.go
+++ b/persistence/test/account_test.go
@@ -381,7 +381,7 @@ func TestGetAllPools(t *testing.T) {
 
 func TestPoolsUpdatedAtHeight(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
-	numPoolsInTestGenesis := len(coreTypes.Pools_value) - 1 // -1 because we don't count the "unspecified" pool (Pools_POOLS_UNSPECIFIED
+	numPoolsInTestGenesis := len(coreTypes.Pools_value) - 1 // -1 because we don't count the "unspecified" pool (Pools_POOLS_UNSPECIFIED)
 
 	// Check num Pools in genesis
 	accs, err := db.GetPoolsUpdated(0)

--- a/persistence/test/state_test.go
+++ b/persistence/test/state_test.go
@@ -46,9 +46,9 @@ func TestStateHash_DeterministicStateWhenUpdatingAppStake(t *testing.T) {
 	// logic changes, these hashes will need to be updated based on the test output.
 	// TODO: Add an explicit updateSnapshots flag to the test to make this more clear.
 	stateHashes := []string{
-		"d319a12cee0b924723e422fd61cd37f68f73e8ac4e0336d75c1a98fff7f62619",
-		"b3c17dd7ea0dbec3ebc223863f4c9cc5535cd00268d88839192929ca89dcd0b7",
-		"3b2c0edd82c12f87eaedb7d55000ff772df9df6c54bdfc89f2dca02ddec38160",
+		"3a9a33c4d6b106f656c859296cd5ac16b608980d1d921f6de77051a707f48cb5",
+		"ec3d62106f1ca61dfe9c1d80a16c4ee3923550db5175389777bd1ecd9d50136e",
+		"e440914fba03bbb5ff4fbb73f760e4e75c3635263bbf7c15ca649870ee865222",
 	}
 
 	stakeAmount := initialStakeAmount

--- a/persistence/test/state_test.go
+++ b/persistence/test/state_test.go
@@ -46,9 +46,9 @@ func TestStateHash_DeterministicStateWhenUpdatingAppStake(t *testing.T) {
 	// logic changes, these hashes will need to be updated based on the test output.
 	// TODO: Add an explicit updateSnapshots flag to the test to make this more clear.
 	stateHashes := []string{
-		"86fa89b366aaa42685122d019071377cec8de3cc9f436895307dda937090edf5",
-		"8d1447be2b5ed72c84c6351a6ebc47c49c7a00f27e362e506fe15e7fd069ff8c",
-		"c62ccfc48106161930b9d0f64ef2b5885dabaae9f2a34728de28b0e80530fb15",
+		"d319a12cee0b924723e422fd61cd37f68f73e8ac4e0336d75c1a98fff7f62619",
+		"b3c17dd7ea0dbec3ebc223863f4c9cc5535cd00268d88839192929ca89dcd0b7",
+		"3b2c0edd82c12f87eaedb7d55000ff772df9df6c54bdfc89f2dca02ddec38160",
 	}
 
 	stakeAmount := initialStakeAmount

--- a/runtime/docs/CHANGELOG.md
+++ b/runtime/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.29] - 2023-04-06
+
+- Updated to reflect pools address changes
+
 ## [0.0.0.28] - 2023-03-30
 
 - Update the configurations for postgres pooling

--- a/runtime/manager_test.go
+++ b/runtime/manager_test.go
@@ -26,27 +26,27 @@ var expectedGenesis = &genesis.GenesisState{
 	MaxBlockBytes: 4000000,
 	Pools: []*types.Account{
 		{
-			Address: "DAO",
+			Address: "44414f0000000000000000000000000000000000",
 			Amount:  "100000000000000",
 		},
 		{
-			Address: "FeeCollector",
+			Address: "466565436f6c6c6563746f720000000000000000",
 			Amount:  "0",
 		},
 		{
-			Address: "AppStakePool",
+			Address: "4170705374616b65506f6f6c0000000000000000",
 			Amount:  "100000000000000",
 		},
 		{
-			Address: "ValidatorStakePool",
+			Address: "56616c696461746f725374616b65506f6f6c0000",
 			Amount:  "100000000000000",
 		},
 		{
-			Address: "ServicerStakePool",
+			Address: "53657276696365725374616b65506f6f6c000000",
 			Amount:  "100000000000000",
 		},
 		{
-			Address: "FishermanStakePool",
+			Address: "4669736865726d616e5374616b65506f6f6c0000",
 			Amount:  "100000000000000",
 		},
 	},

--- a/runtime/test_artifacts/generator.go
+++ b/runtime/test_artifacts/generator.go
@@ -49,17 +49,19 @@ func NewDefaultConfigs(privateKeys []string) (cfgs []*configs.Config) {
 
 // REFACTOR: Test artifact generator should reflect the sum of the initial account values to populate the initial pool values
 func NewPools() (pools []*coreTypes.Account) {
-	for _, name := range coreTypes.Pools_name {
-		if name == coreTypes.Pools_POOLS_FEE_COLLECTOR.FriendlyName() {
-			pools = append(pools, &coreTypes.Account{
-				Address: name,
-				Amount:  "0",
-			})
+	for _, value := range coreTypes.Pools_value {
+		if value == int32(coreTypes.Pools_POOLS_UNSPECIFIED) {
 			continue
 		}
+
+		amount := DefaultAccountAmountString
+		if value == int32(coreTypes.Pools_POOLS_FEE_COLLECTOR) {
+			amount = "0"
+		}
+
 		pools = append(pools, &coreTypes.Account{
-			Address: name,
-			Amount:  DefaultAccountAmountString,
+			Address: coreTypes.Pools(value).Address(),
+			Amount:  amount,
 		})
 	}
 	return

--- a/runtime/test_artifacts/generator.go
+++ b/runtime/test_artifacts/generator.go
@@ -2,6 +2,7 @@ package test_artifacts
 
 // Cross module imports are okay because this is only used for testing and not business logic
 import (
+	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -60,7 +61,7 @@ func NewPools() (pools []*coreTypes.Account) {
 		}
 
 		pools = append(pools, &coreTypes.Account{
-			Address: coreTypes.Pools(value).Address(),
+			Address: hex.EncodeToString(coreTypes.Pools(value).Address()),
 			Amount:  amount,
 		})
 	}

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.47] - 2023-04-06
+
+- Updated to reflect pools address changes
+- Added tests to catch, in a future-proof way, changes to our pools
+- Updated interfaces to use `[]byte` instead of `string` for `pool` addresses for consistency with `accounts` and because otherwise fuzzy tests would fail
+
 ## [0.0.0.46] - 2023-04-03
 
 - Add `ConsensusStateSync` interface. It defines exported state sync functions in consensus module

--- a/shared/core/types/pools.go
+++ b/shared/core/types/pools.go
@@ -1,7 +1,7 @@
 package types
 
 var poolFriendlyNames map[Pools]string
-var poolAddresses map[Pools]string
+var poolAddresses map[Pools][]byte
 
 func init() {
 	poolFriendlyNames = map[Pools]string{
@@ -15,14 +15,14 @@ func init() {
 	}
 
 	// poolAddresses is a map of pools to their addresses. This is to avoid using the hack of using the pool name as the address
-	poolAddresses = map[Pools]string{
-		Pools_POOLS_UNSPECIFIED:     "",
-		Pools_POOLS_DAO:             "44414f0000000000000000000000000000000000",
-		Pools_POOLS_FEE_COLLECTOR:   "466565436f6c6c6563746f720000000000000000",
-		Pools_POOLS_APP_STAKE:       "4170705374616b65506f6f6c0000000000000000",
-		Pools_POOLS_VALIDATOR_STAKE: "56616c696461746f725374616b65506f6f6c0000",
-		Pools_POOLS_SERVICER_STAKE:  "53657276696365725374616b65506f6f6c000000",
-		Pools_POOLS_FISHERMAN_STAKE: "4669736865726d616e5374616b65506f6f6c0000",
+	poolAddresses = map[Pools][]byte{
+		Pools_POOLS_UNSPECIFIED:     []byte(""),
+		Pools_POOLS_DAO:             []byte("44414f0000000000000000000000000000000000"),
+		Pools_POOLS_FEE_COLLECTOR:   []byte("466565436f6c6c6563746f720000000000000000"),
+		Pools_POOLS_APP_STAKE:       []byte("4170705374616b65506f6f6c0000000000000000"),
+		Pools_POOLS_VALIDATOR_STAKE: []byte("56616c696461746f725374616b65506f6f6c0000"),
+		Pools_POOLS_SERVICER_STAKE:  []byte("53657276696365725374616b65506f6f6c000000"),
+		Pools_POOLS_FISHERMAN_STAKE: []byte("4669736865726d616e5374616b65506f6f6c0000"),
 	}
 }
 
@@ -30,6 +30,6 @@ func (pn Pools) FriendlyName() string {
 	return poolFriendlyNames[pn]
 }
 
-func (pn Pools) Address() string {
+func (pn Pools) Address() []byte {
 	return poolAddresses[pn]
 }

--- a/shared/core/types/pools.go
+++ b/shared/core/types/pools.go
@@ -1,18 +1,35 @@
 package types
 
 var poolFriendlyNames map[Pools]string
+var poolAddresses map[Pools]string
 
 func init() {
 	poolFriendlyNames = map[Pools]string{
-		Pools_POOLS_UNSPECIFIED:     "Unspecified",
+		Pools_POOLS_UNSPECIFIED:     "",
 		Pools_POOLS_DAO:             "DAO",
 		Pools_POOLS_FEE_COLLECTOR:   "FeeCollector",
 		Pools_POOLS_APP_STAKE:       "AppStakePool",
 		Pools_POOLS_VALIDATOR_STAKE: "ValidatorStakePool",
 		Pools_POOLS_SERVICER_STAKE:  "ServicerStakePool",
+		Pools_POOLS_FISHERMAN_STAKE: "FishermanStakePool",
+	}
+
+	// poolAddresses is a map of pools to their addresses. This is to avoid using the hack of using the pool name as the address
+	poolAddresses = map[Pools]string{
+		Pools_POOLS_UNSPECIFIED:     "",
+		Pools_POOLS_DAO:             "44414f0000000000000000000000000000000000",
+		Pools_POOLS_FEE_COLLECTOR:   "466565436f6c6c6563746f720000000000000000",
+		Pools_POOLS_APP_STAKE:       "4170705374616b65506f6f6c0000000000000000",
+		Pools_POOLS_VALIDATOR_STAKE: "56616c696461746f725374616b65506f6f6c0000",
+		Pools_POOLS_SERVICER_STAKE:  "53657276696365725374616b65506f6f6c000000",
+		Pools_POOLS_FISHERMAN_STAKE: "4669736865726d616e5374616b65506f6f6c0000",
 	}
 }
 
 func (pn Pools) FriendlyName() string {
 	return poolFriendlyNames[pn]
+}
+
+func (pn Pools) Address() string {
+	return poolAddresses[pn]
 }

--- a/shared/core/types/pools_test.go
+++ b/shared/core/types/pools_test.go
@@ -47,6 +47,7 @@ func TestPools_Address(t *testing.T) {
 
 // convertFriendlyNameToHexBytes is the function used to opinionatedly convert a pool name into a valid address
 // this is done by encoding to hex and padding to 40 characters with zeros
+// TODO: consider doing the same as V0 (https://github.com/pokt-network/pocket-core/blob/a109dfc03a13eec06413bf1eb7d17fe093f96842/x/auth/types/account.go#L320)
 func convertFriendlyNameToHexBytes(s string) ([]byte, error) {
 	if s == "" {
 		return []byte(""), nil

--- a/shared/core/types/pools_test.go
+++ b/shared/core/types/pools_test.go
@@ -34,21 +34,21 @@ func TestPools_Address(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			name := tt.pn.FriendlyName()
-			want, err := convertStringToHex(name)
+			want, err := convertFriendlyNameToHexBytes(name)
 			require.NoError(t, err)
 
-			if got := tt.pn.Address(); got != want {
-				t.Errorf("Pools.Address() = %v, want %v", got, want)
+			if got := tt.pn.Address(); string(got) != string(want) {
+				t.Errorf("Pools.Address() = %v, want %v", string(got), string(want))
 			}
 		})
 	}
 }
 
-// convertStringToHex is the function used to opinionatedly convert a pool name into a valid address
+// convertFriendlyNameToHexBytes is the function used to opinionatedly convert a pool name into a valid address
 // this is done by encoding to hex and padding to 40 characters with zeros
-func convertStringToHex(s string) (string, error) {
+func convertFriendlyNameToHexBytes(s string) ([]byte, error) {
 	if len(s) == 0 {
-		return "", nil
+		return []byte(""), nil
 	}
 	src := []byte(s)
 	dst := make([]byte, hex.EncodedLen(len(src)))
@@ -56,11 +56,11 @@ func convertStringToHex(s string) (string, error) {
 	encodedStr := string(dst)
 
 	if len(encodedStr) > 40 {
-		return "", errors.New("the resulting string is longer than 40 characters")
+		return []byte(""), errors.New("the resulting string is longer than 40 characters")
 	}
 
 	// Add zeros to the end of the encoded string until it reaches 40 characters
 	paddedStr := encodedStr + strings.Repeat("0", 40-len(encodedStr))
 
-	return paddedStr, nil
+	return []byte(paddedStr), nil
 }

--- a/shared/core/types/pools_test.go
+++ b/shared/core/types/pools_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"strings"
@@ -37,7 +38,7 @@ func TestPools_Address(t *testing.T) {
 			want, err := convertFriendlyNameToHexBytes(name)
 			require.NoError(t, err)
 
-			if got := tt.pn.Address(); string(got) != string(want) {
+			if got := tt.pn.Address(); !bytes.Equal(got, want) {
 				t.Errorf("Pools.Address() = %v, want %v", string(got), string(want))
 			}
 		})
@@ -47,7 +48,7 @@ func TestPools_Address(t *testing.T) {
 // convertFriendlyNameToHexBytes is the function used to opinionatedly convert a pool name into a valid address
 // this is done by encoding to hex and padding to 40 characters with zeros
 func convertFriendlyNameToHexBytes(s string) ([]byte, error) {
-	if len(s) == 0 {
+	if s == "" {
 		return []byte(""), nil
 	}
 	src := []byte(s)

--- a/shared/core/types/pools_test.go
+++ b/shared/core/types/pools_test.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPools_Address(t *testing.T) {
+	tests := []struct {
+		name string
+		pn   Pools
+	}{
+		// initializing tests with the custom/edge cases
+		{"unspecified", Pools_POOLS_UNSPECIFIED},
+		{"invalid", Pools(100)},
+	}
+
+	// adding all the real world cases programmatically in order to catch any changes to the enum
+	// that must be reflected into the hardcoded values
+	for _, pool := range Pools_value {
+		tests = append(tests, struct {
+			name string
+			pn   Pools
+		}{
+			name: Pools(pool).FriendlyName(),
+			pn:   Pools(pool),
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := tt.pn.FriendlyName()
+			want, err := convertStringToHex(name)
+			require.NoError(t, err)
+
+			if got := tt.pn.Address(); got != want {
+				t.Errorf("Pools.Address() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// convertStringToHex is the function used to opinionatedly convert a pool name into a valid address
+// this is done by encoding to hex and padding to 40 characters with zeros
+func convertStringToHex(s string) (string, error) {
+	if len(s) == 0 {
+		return "", nil
+	}
+	src := []byte(s)
+	dst := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(dst, src)
+	encodedStr := string(dst)
+
+	if len(encodedStr) > 40 {
+		return "", errors.New("the resulting string is longer than 40 characters")
+	}
+
+	// Add zeros to the end of the encoded string until it reaches 40 characters
+	paddedStr := encodedStr + strings.Repeat("0", 40-len(encodedStr))
+
+	return paddedStr, nil
+}

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -76,10 +76,10 @@ type PersistenceWriteContext interface {
 	IndexTransaction(txResult TxResult) error
 
 	// Pool Operations
-	AddPoolAmount(name string, amount string) error
-	SubtractPoolAmount(name string, amount string) error
-	SetPoolAmount(name string, amount string) error
-	InsertPool(name string, amount string) error
+	AddPoolAmount(address []byte, amount string) error
+	SubtractPoolAmount(address []byte, amount string) error
+	SetPoolAmount(address []byte, amount string) error
+	InsertPool(address []byte, amount string) error
 
 	// Account Operations
 	AddAccountAmount(address []byte, amount string) error
@@ -142,7 +142,7 @@ type PersistenceReadContext interface {
 	// Pool Queries
 
 	// Returns "0" if the account does not exist
-	GetPoolAmount(name string, height int64) (amount string, err error)
+	GetPoolAmount(address []byte, height int64) (amount string, err error)
 	GetAllPools(height int64) ([]*coreTypes.Account, error)
 
 	// Account Queries

--- a/utility/doc/CHANGELOG.md
+++ b/utility/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.34] - 2023-04-06
+
+- Updated to reflect pools address changes
+
 ## [0.0.0.33] - 2023-03-30
 
 - Improved logging throughout the module

--- a/utility/types/error.go
+++ b/utility/types/error.go
@@ -498,24 +498,24 @@ func ErrAddAccountAmount(err error) Error {
 	return NewError(CodeAddAccountAmountError, fmt.Sprintf("%s: %s", AddAccountAmountError, err.Error()))
 }
 
-func ErrAddPoolAmount(name string, err error) Error {
-	return NewError(CodeAddPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", AddPoolAmountError, name, err.Error()))
+func ErrAddPoolAmount(address []byte, err error) Error {
+	return NewError(CodeAddPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", AddPoolAmountError, hex.EncodeToString(address), err.Error()))
 }
 
-func ErrSubPoolAmount(name string, err error) Error {
-	return NewError(CodeSubPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", SubPoolAmountError, name, err.Error()))
+func ErrSubPoolAmount(address []byte, err error) Error {
+	return NewError(CodeSubPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", SubPoolAmountError, hex.EncodeToString(address), err.Error()))
 }
 
-func ErrSetPoolAmount(name string, err error) Error {
-	return NewError(CodeSetPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", SetPoolAmountError, name, err.Error()))
+func ErrSetPoolAmount(address []byte, err error) Error {
+	return NewError(CodeSetPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", SetPoolAmountError, hex.EncodeToString(address), err.Error()))
 }
 
-func ErrSetPool(name string, err error) Error {
-	return NewError(CodeSetPoolError, fmt.Sprintf("%s: pool: %s, %s", SetPoolError, name, err.Error()))
+func ErrSetPool(address []byte, err error) Error {
+	return NewError(CodeSetPoolError, fmt.Sprintf("%s: pool: %s, %s", SetPoolError, hex.EncodeToString(address), err.Error()))
 }
 
-func ErrGetPoolAmount(name string, err error) Error {
-	return NewError(CodeGetPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", GetPoolAmountError, name, err.Error()))
+func ErrGetPoolAmount(address []byte, err error) Error {
+	return NewError(CodeGetPoolAmountError, fmt.Sprintf("%s: pool: %s, %s", GetPoolAmountError, hex.EncodeToString(address), err.Error()))
 }
 
 func ErrSetAccountAmount(err error) Error {

--- a/utility/unit_of_work/account.go
+++ b/utility/unit_of_work/account.go
@@ -49,19 +49,17 @@ func (u *baseUtilityUnitOfWork) setAccountAmount(address []byte, amount *big.Int
 
 // Pools specific functionality
 
-// IMPROVE: Pool function should accept the actual pool types rather than the `FriendlyName` string
-
-func (u *baseUtilityUnitOfWork) insertPool(name string, amount *big.Int) types.Error {
-	if err := u.persistenceRWContext.InsertPool(name, utils.BigIntToString(amount)); err != nil {
-		return types.ErrSetPool(name, err)
+func (u *baseUtilityUnitOfWork) insertPool(address string, amount *big.Int) types.Error {
+	if err := u.persistenceRWContext.InsertPool(address, utils.BigIntToString(amount)); err != nil {
+		return types.ErrSetPool(address, err)
 	}
 	return nil
 }
 
-func (u *baseUtilityUnitOfWork) getPoolAmount(name string) (*big.Int, types.Error) {
-	amountStr, err := u.persistenceReadContext.GetPoolAmount(name, u.height)
+func (u *baseUtilityUnitOfWork) getPoolAmount(address string) (*big.Int, types.Error) {
+	amountStr, err := u.persistenceReadContext.GetPoolAmount(address, u.height)
 	if err != nil {
-		return nil, types.ErrGetPoolAmount(name, err)
+		return nil, types.ErrGetPoolAmount(address, err)
 	}
 	amount, err := utils.StringToBigInt(amountStr)
 	if err != nil {
@@ -70,23 +68,23 @@ func (u *baseUtilityUnitOfWork) getPoolAmount(name string) (*big.Int, types.Erro
 	return amount, nil
 }
 
-func (u *baseUtilityUnitOfWork) addPoolAmount(name string, amountToAdd *big.Int) types.Error {
-	if err := u.persistenceRWContext.AddPoolAmount(name, utils.BigIntToString(amountToAdd)); err != nil {
-		return types.ErrAddPoolAmount(name, err)
+func (u *baseUtilityUnitOfWork) addPoolAmount(address string, amountToAdd *big.Int) types.Error {
+	if err := u.persistenceRWContext.AddPoolAmount(address, utils.BigIntToString(amountToAdd)); err != nil {
+		return types.ErrAddPoolAmount(address, err)
 	}
 	return nil
 }
 
-func (u *baseUtilityUnitOfWork) subPoolAmount(name string, amountToSub *big.Int) types.Error {
-	if err := u.persistenceRWContext.SubtractPoolAmount(name, utils.BigIntToString(amountToSub)); err != nil {
-		return types.ErrSubPoolAmount(name, err)
+func (u *baseUtilityUnitOfWork) subPoolAmount(address string, amountToSub *big.Int) types.Error {
+	if err := u.persistenceRWContext.SubtractPoolAmount(address, utils.BigIntToString(amountToSub)); err != nil {
+		return types.ErrSubPoolAmount(address, err)
 	}
 	return nil
 }
 
-func (u *baseUtilityUnitOfWork) setPoolAmount(name string, amount *big.Int) types.Error {
-	if err := u.persistenceRWContext.SetPoolAmount(name, utils.BigIntToString(amount)); err != nil {
-		return types.ErrSetPoolAmount(name, err)
+func (u *baseUtilityUnitOfWork) setPoolAmount(address string, amount *big.Int) types.Error {
+	if err := u.persistenceRWContext.SetPoolAmount(address, utils.BigIntToString(amount)); err != nil {
+		return types.ErrSetPoolAmount(address, err)
 	}
 	return nil
 }

--- a/utility/unit_of_work/account.go
+++ b/utility/unit_of_work/account.go
@@ -49,14 +49,14 @@ func (u *baseUtilityUnitOfWork) setAccountAmount(address []byte, amount *big.Int
 
 // Pools specific functionality
 
-func (u *baseUtilityUnitOfWork) insertPool(address string, amount *big.Int) types.Error {
+func (u *baseUtilityUnitOfWork) insertPool(address []byte, amount *big.Int) types.Error {
 	if err := u.persistenceRWContext.InsertPool(address, utils.BigIntToString(amount)); err != nil {
 		return types.ErrSetPool(address, err)
 	}
 	return nil
 }
 
-func (u *baseUtilityUnitOfWork) getPoolAmount(address string) (*big.Int, types.Error) {
+func (u *baseUtilityUnitOfWork) getPoolAmount(address []byte) (*big.Int, types.Error) {
 	amountStr, err := u.persistenceReadContext.GetPoolAmount(address, u.height)
 	if err != nil {
 		return nil, types.ErrGetPoolAmount(address, err)
@@ -68,21 +68,21 @@ func (u *baseUtilityUnitOfWork) getPoolAmount(address string) (*big.Int, types.E
 	return amount, nil
 }
 
-func (u *baseUtilityUnitOfWork) addPoolAmount(address string, amountToAdd *big.Int) types.Error {
+func (u *baseUtilityUnitOfWork) addPoolAmount(address []byte, amountToAdd *big.Int) types.Error {
 	if err := u.persistenceRWContext.AddPoolAmount(address, utils.BigIntToString(amountToAdd)); err != nil {
 		return types.ErrAddPoolAmount(address, err)
 	}
 	return nil
 }
 
-func (u *baseUtilityUnitOfWork) subPoolAmount(address string, amountToSub *big.Int) types.Error {
+func (u *baseUtilityUnitOfWork) subPoolAmount(address []byte, amountToSub *big.Int) types.Error {
 	if err := u.persistenceRWContext.SubtractPoolAmount(address, utils.BigIntToString(amountToSub)); err != nil {
 		return types.ErrSubPoolAmount(address, err)
 	}
 	return nil
 }
 
-func (u *baseUtilityUnitOfWork) setPoolAmount(address string, amount *big.Int) types.Error {
+func (u *baseUtilityUnitOfWork) setPoolAmount(address []byte, amount *big.Int) types.Error {
 	if err := u.persistenceRWContext.SetPoolAmount(address, utils.BigIntToString(amount)); err != nil {
 		return types.ErrSetPoolAmount(address, err)
 	}

--- a/utility/unit_of_work/account_test.go
+++ b/utility/unit_of_work/account_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/pokt-network/pocket/runtime/test_artifacts/keygen"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
 	"github.com/pokt-network/pocket/shared/crypto"
 	"github.com/pokt-network/pocket/shared/utils"
@@ -68,14 +69,16 @@ func TestUtilityUnitOfWork_SetAccountAmount(t *testing.T) {
 func TestUtilityUnitOfWork_AddPoolAmount(t *testing.T) {
 	uow := newTestingUtilityUnitOfWork(t, 0)
 	pool := getFirstTestingPool(t, uow)
+	addrBz, err := hex.DecodeString(pool.Address)
+	require.NoError(t, err)
 
 	initialAmount, err := utils.StringToBigInt(pool.GetAmount())
 	require.NoError(t, err)
 
 	addAmount := big.NewInt(1)
-	require.NoError(t, uow.addPoolAmount(pool.GetAddress(), addAmount), "add pool amount")
+	require.NoError(t, uow.addPoolAmount(addrBz, addAmount), "add pool amount")
 
-	afterAmount, err := uow.getPoolAmount(pool.GetAddress())
+	afterAmount, err := uow.getPoolAmount(addrBz)
 	require.NoError(t, err)
 
 	expected := initialAmount.Add(initialAmount, addAmount)
@@ -84,13 +87,16 @@ func TestUtilityUnitOfWork_AddPoolAmount(t *testing.T) {
 
 func TestUtilityUnitOfWork_InsertPool(t *testing.T) {
 	uow := newTestingUtilityUnitOfWork(t, 0)
-	testPoolName := "TEST_POOL"
+
+	_, _, poolAddr := keygen.GetInstance().Next()
+	addrBz, err := hex.DecodeString(poolAddr)
+	require.NoError(t, err)
 
 	amount := big.NewInt(1000)
-	err := uow.insertPool(testPoolName, amount)
+	err = uow.insertPool(addrBz, amount)
 	require.NoError(t, err, "insert pool")
 
-	poolAmount, err := uow.getPoolAmount(testPoolName)
+	poolAmount, err := uow.getPoolAmount(addrBz)
 	require.NoError(t, err)
 	require.Equal(t, amount, poolAmount)
 }
@@ -98,14 +104,16 @@ func TestUtilityUnitOfWork_InsertPool(t *testing.T) {
 func TestUtilityUnitOfWork_SetPoolAmount(t *testing.T) {
 	uow := newTestingUtilityUnitOfWork(t, 0)
 	pool := getFirstTestingPool(t, uow)
+	addrBz, err := hex.DecodeString(pool.GetAddress())
+	require.NoError(t, err)
 
 	beforeAmount, err := utils.StringToBigInt(pool.GetAmount())
 	require.NoError(t, err)
 
 	expectedAfterAmount := big.NewInt(100)
-	require.NoError(t, uow.setPoolAmount(pool.GetAddress(), expectedAfterAmount), "set pool amount")
+	require.NoError(t, uow.setPoolAmount(addrBz, expectedAfterAmount), "set pool amount")
 
-	amount, err := uow.getPoolAmount(pool.GetAddress())
+	amount, err := uow.getPoolAmount(addrBz)
 	require.NoError(t, err)
 	require.NotEqual(t, beforeAmount, amount)
 	require.Equal(t, amount, expectedAfterAmount)
@@ -114,14 +122,16 @@ func TestUtilityUnitOfWork_SetPoolAmount(t *testing.T) {
 func TestUtilityUnitOfWork_SubPoolAmount(t *testing.T) {
 	uow := newTestingUtilityUnitOfWork(t, 0)
 	pool := getFirstTestingPool(t, uow)
+	addrBz, err := hex.DecodeString(pool.GetAddress())
+	require.NoError(t, err)
 
 	beforeAmountBig := big.NewInt(1000000000000000)
-	require.NoError(t, uow.setPoolAmount(pool.GetAddress(), beforeAmountBig))
+	require.NoError(t, uow.setPoolAmount(addrBz, beforeAmountBig))
 
 	subAmount := big.NewInt(100)
-	require.NoError(t, uow.subPoolAmount(pool.GetAddress(), subAmount), "sub pool amount")
+	require.NoError(t, uow.subPoolAmount(addrBz, subAmount), "sub pool amount")
 
-	amount, err := uow.getPoolAmount(pool.GetAddress())
+	amount, err := uow.getPoolAmount(addrBz)
 	require.NoError(t, err)
 	require.NotEqual(t, beforeAmountBig, amount)
 

--- a/utility/unit_of_work/actor_test.go
+++ b/utility/unit_of_work/actor_test.go
@@ -376,7 +376,7 @@ func TestUtilityUnitOfWork_BeginUnstakingActorsPausedBefore_UnbondUnstakingActor
 		t.Run(fmt.Sprintf("%s.BeginUnstakingActorsPausedBefore", actorType.String()), func(t *testing.T) {
 			uow := newTestingUtilityUnitOfWork(t, 1)
 
-			var poolAddress string
+			var poolAddress []byte
 			var paramName1 string
 			var paramName2 string
 			switch actorType {

--- a/utility/unit_of_work/actor_test.go
+++ b/utility/unit_of_work/actor_test.go
@@ -376,24 +376,24 @@ func TestUtilityUnitOfWork_BeginUnstakingActorsPausedBefore_UnbondUnstakingActor
 		t.Run(fmt.Sprintf("%s.BeginUnstakingActorsPausedBefore", actorType.String()), func(t *testing.T) {
 			uow := newTestingUtilityUnitOfWork(t, 1)
 
-			var poolName string
+			var poolAddress string
 			var paramName1 string
 			var paramName2 string
 			switch actorType {
 			case coreTypes.ActorType_ACTOR_TYPE_APP:
-				poolName = coreTypes.Pools_POOLS_APP_STAKE.FriendlyName()
+				poolAddress = coreTypes.Pools_POOLS_APP_STAKE.Address()
 				paramName1 = typesUtil.AppMaxPauseBlocksParamName
 				paramName2 = typesUtil.AppUnstakingBlocksParamName
 			case coreTypes.ActorType_ACTOR_TYPE_FISH:
-				poolName = coreTypes.Pools_POOLS_FISHERMAN_STAKE.FriendlyName()
+				poolAddress = coreTypes.Pools_POOLS_FISHERMAN_STAKE.Address()
 				paramName1 = typesUtil.FishermanMaxPauseBlocksParamName
 				paramName2 = typesUtil.FishermanUnstakingBlocksParamName
 			case coreTypes.ActorType_ACTOR_TYPE_SERVICER:
-				poolName = coreTypes.Pools_POOLS_SERVICER_STAKE.FriendlyName()
+				poolAddress = coreTypes.Pools_POOLS_SERVICER_STAKE.Address()
 				paramName1 = typesUtil.ServicerMaxPauseBlocksParamName
 				paramName2 = typesUtil.ServicerUnstakingBlocksParamName
 			case coreTypes.ActorType_ACTOR_TYPE_VAL:
-				poolName = coreTypes.Pools_POOLS_VALIDATOR_STAKE.FriendlyName()
+				poolAddress = coreTypes.Pools_POOLS_VALIDATOR_STAKE.Address()
 				paramName1 = typesUtil.ValidatorMaxPausedBlocksParamName
 				paramName2 = typesUtil.ValidatorUnstakingBlocksParamName
 			default:
@@ -404,7 +404,7 @@ func TestUtilityUnitOfWork_BeginUnstakingActorsPausedBefore_UnbondUnstakingActor
 			require.NoError(t, er, "error setting max paused blocks")
 			er = uow.persistenceRWContext.SetParam(paramName2, unstakingBlocks)
 			require.NoError(t, er, "error setting max paused blocks")
-			er = uow.setPoolAmount(poolName, poolInitAMount)
+			er = uow.setPoolAmount(poolAddress, poolInitAMount)
 			require.NoError(t, er)
 
 			// Validate the actor is not unstaking
@@ -454,7 +454,7 @@ func TestUtilityUnitOfWork_BeginUnstakingActorsPausedBefore_UnbondUnstakingActor
 			uow = newTestingUtilityUnitOfWork(t, unbondingHeight)
 
 			// Before unbonding, the pool amount should be unchanged
-			amount, err := uow.getPoolAmount(poolName)
+			amount, err := uow.getPoolAmount(poolAddress)
 			require.NoError(t, err)
 			require.Equal(t, poolInitAMount, amount, "pool amount should be unchanged")
 
@@ -462,13 +462,13 @@ func TestUtilityUnitOfWork_BeginUnstakingActorsPausedBefore_UnbondUnstakingActor
 			require.NoError(t, err)
 
 			// Before unbonding, the money from the staked actor should go to the pool
-			amount, err = uow.getPoolAmount(poolName)
+			amount, err = uow.getPoolAmount(poolAddress)
 			require.NoError(t, err)
 
 			stakedAmount, err := utils.StringToBigInt(actor.StakedAmount)
 			require.NoError(t, err)
 			expectedAmount := big.NewInt(0).Sub(poolInitAMount, stakedAmount)
-			require.Equalf(t, expectedAmount, amount, "pool amount should be unchanged for %s", poolName)
+			require.Equalf(t, expectedAmount, amount, "pool amount should be unchanged for %s", poolAddress)
 
 			// Status should be changed from Unstaking to Unstaked
 			status, err = uow.getActorStatus(actorType, addrBz)

--- a/utility/unit_of_work/block.go
+++ b/utility/unit_of_work/block.go
@@ -85,7 +85,7 @@ func (u *baseUtilityUnitOfWork) unbondUnstakingActors() (err typesUtil.Error) {
 		actorType := coreTypes.ActorType(actorTypeNum)
 
 		var readyToUnbond []*moduleTypes.UnstakingActor
-		var poolAddress string
+		var poolAddress []byte
 
 		var er error
 		switch actorType {

--- a/utility/unit_of_work/block.go
+++ b/utility/unit_of_work/block.go
@@ -41,14 +41,14 @@ func (u *baseUtilityUnitOfWork) endBlock(proposer []byte) typesUtil.Error {
 }
 
 func (u *baseUtilityUnitOfWork) handleProposerRewards(proposer []byte) typesUtil.Error {
-	feePoolName := coreTypes.Pools_POOLS_FEE_COLLECTOR.FriendlyName()
-	feesAndRewardsCollected, err := u.getPoolAmount(feePoolName)
+	feePoolAddress := coreTypes.Pools_POOLS_FEE_COLLECTOR.Address()
+	feesAndRewardsCollected, err := u.getPoolAmount(feePoolAddress)
 	if err != nil {
 		return err
 	}
 
 	// Nullify the rewards pool
-	if err := u.setPoolAmount(feePoolName, big.NewInt(0)); err != nil {
+	if err := u.setPoolAmount(feePoolAddress, big.NewInt(0)); err != nil {
 		return err
 	}
 
@@ -71,7 +71,7 @@ func (u *baseUtilityUnitOfWork) handleProposerRewards(proposer []byte) typesUtil
 	if err := u.addAccountAmount(proposer, amountToProposer); err != nil {
 		return err
 	}
-	if err := u.addPoolAmount(coreTypes.Pools_POOLS_DAO.FriendlyName(), amountToDAO); err != nil {
+	if err := u.addPoolAmount(coreTypes.Pools_POOLS_DAO.Address(), amountToDAO); err != nil {
 		return err
 	}
 	return nil
@@ -85,22 +85,22 @@ func (u *baseUtilityUnitOfWork) unbondUnstakingActors() (err typesUtil.Error) {
 		actorType := coreTypes.ActorType(actorTypeNum)
 
 		var readyToUnbond []*moduleTypes.UnstakingActor
-		var poolName string
+		var poolAddress string
 
 		var er error
 		switch actorType {
 		case coreTypes.ActorType_ACTOR_TYPE_APP:
 			readyToUnbond, er = u.persistenceReadContext.GetAppsReadyToUnstake(u.height, int32(coreTypes.StakeStatus_Unstaking))
-			poolName = coreTypes.Pools_POOLS_APP_STAKE.FriendlyName()
+			poolAddress = coreTypes.Pools_POOLS_APP_STAKE.Address()
 		case coreTypes.ActorType_ACTOR_TYPE_FISH:
 			readyToUnbond, er = u.persistenceReadContext.GetFishermenReadyToUnstake(u.height, int32(coreTypes.StakeStatus_Unstaking))
-			poolName = coreTypes.Pools_POOLS_FISHERMAN_STAKE.FriendlyName()
+			poolAddress = coreTypes.Pools_POOLS_FISHERMAN_STAKE.Address()
 		case coreTypes.ActorType_ACTOR_TYPE_SERVICER:
 			readyToUnbond, er = u.persistenceReadContext.GetServicersReadyToUnstake(u.height, int32(coreTypes.StakeStatus_Unstaking))
-			poolName = coreTypes.Pools_POOLS_SERVICER_STAKE.FriendlyName()
+			poolAddress = coreTypes.Pools_POOLS_SERVICER_STAKE.Address()
 		case coreTypes.ActorType_ACTOR_TYPE_VAL:
 			readyToUnbond, er = u.persistenceReadContext.GetValidatorsReadyToUnstake(u.height, int32(coreTypes.StakeStatus_Unstaking))
-			poolName = coreTypes.Pools_POOLS_VALIDATOR_STAKE.FriendlyName()
+			poolAddress = coreTypes.Pools_POOLS_VALIDATOR_STAKE.Address()
 		case coreTypes.ActorType_ACTOR_TYPE_UNSPECIFIED:
 			continue
 		}
@@ -121,7 +121,7 @@ func (u *baseUtilityUnitOfWork) unbondUnstakingActors() (err typesUtil.Error) {
 				return typesUtil.ErrHexDecodeFromString(err)
 			}
 
-			if err := u.subPoolAmount(poolName, stakeAmount); err != nil {
+			if err := u.subPoolAmount(poolAddress, stakeAmount); err != nil {
 				return err
 			}
 			if err := u.addAccountAmount(outputAddrBz, stakeAmount); err != nil {

--- a/utility/unit_of_work/transaction.go
+++ b/utility/unit_of_work/transaction.go
@@ -82,7 +82,7 @@ func (u *baseUtilityUnitOfWork) anteHandleMessage(tx *coreTypes.Transaction) (ty
 	if err := u.setAccountAmount(address, accountAmount); err != nil {
 		return nil, err
 	}
-	if err := u.addPoolAmount(coreTypes.Pools_POOLS_FEE_COLLECTOR.FriendlyName(), fee); err != nil {
+	if err := u.addPoolAmount(coreTypes.Pools_POOLS_FEE_COLLECTOR.Address(), fee); err != nil {
 		return nil, err
 	}
 

--- a/utility/unit_of_work/tx_message_handler.go
+++ b/utility/unit_of_work/tx_message_handler.go
@@ -95,7 +95,7 @@ func (u *baseUtilityUnitOfWork) handleStakeMessage(message *typesUtil.MessageSta
 		return err
 	}
 	// move funds from account to pool
-	if err := u.addPoolAmount(coreTypes.Pools_POOLS_APP_STAKE.FriendlyName(), amount); err != nil {
+	if err := u.addPoolAmount(coreTypes.Pools_POOLS_APP_STAKE.Address(), amount); err != nil {
 		return err
 	}
 
@@ -154,7 +154,7 @@ func (u *baseUtilityUnitOfWork) handleEditStakeMessage(message *typesUtil.Messag
 		return err
 	}
 	// move funds from account to pool
-	if err := u.addPoolAmount(coreTypes.Pools_POOLS_APP_STAKE.FriendlyName(), amount); err != nil {
+	if err := u.addPoolAmount(coreTypes.Pools_POOLS_APP_STAKE.Address(), amount); err != nil {
 		return err
 	}
 	switch message.ActorType {

--- a/utility/unit_of_work/validator.go
+++ b/utility/unit_of_work/validator.go
@@ -84,7 +84,7 @@ func (u *baseUtilityUnitOfWork) burnValidator(addr []byte) typesUtil.Error {
 	}
 
 	// remove burnt stake amount from the pool
-	if err := u.subPoolAmount(actorPool.FriendlyName(), burnAmountTruncated); err != nil {
+	if err := u.subPoolAmount(actorPool.Address(), burnAmountTruncated); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description

While working on #327 (KV Store PR) I realized that the scope was growing and it sounded sensible to create a specific PR with these fixes that I believe are gonna be needed regardless.

## Issue

I didn't bother creating an issue since I guess this constitutes bug/techdebt even if it's necessary work for #327 if we move forward with the KV store approach.

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Fixed flag/params keying. It was using the hash of the value and not the name, making queries by name impossible
![image](https://user-images.githubusercontent.com/29378614/230366398-6f56cce2-6183-47b0-a259-6c05f17890c7.png)
- Updated pools read/write functions to use a real address, not a string that is named address and obviously is not hexadecimal etc, etc.
- Added test to describe behaviour and catch future bugs (we already missed a pool that wasn't added to the FriendlyNames: `Pools_POOLS_FISHERMAN_STAKE`)
- Updated runtime and tests to reflect the changes

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
