### PR TITLE
[CLI] Debug subcommand extension

### DIFF
--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -85,7 +85,7 @@ func NewDebugSubCommands() []*cobra.Command {
 	for idx, promptItem := range items {
 		commands[idx] = &cobra.Command{
 			Use: promptItem,
-			Run: func(cmd *cobra.Command, args []string) {
+			PersistentPreRun: func(cmd *cobra.Command, args []string) {
 				// TECHDEBT: this is to keep backwards compatibility with localnet
 				configPath = runtime.GetEnv("CONFIG_PATH", "build/config/config1.json")
 
@@ -120,12 +120,12 @@ func NewDebugSubCommands() []*cobra.Command {
 				if err != nil {
 					logger.Global.Fatal().Err(err).Msg("Failed to create p2p module")
 				}
-
 				if err := p2pMod.Start(); err != nil {
 					logger.Global.Fatal().Err(err).Msg("Failed to start p2p module")
 				}
-
-				handleSelect(cmd, promptItem)
+			},
+			Run: func(cmd *cobra.Command, args []string) {
+				handleSelect(cmd, cmd.Use)
 			},
 			ValidArgs: items,
 		}

--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -82,9 +82,9 @@ func init() {
 // write a function handler to match for it in `handleSelect`.
 func NewDebugSubCommands() []*cobra.Command {
 	commands := make([]*cobra.Command, len(items))
-	for idx, debugCmd := range items {
+	for idx, promptItem := range items {
 		commands[idx] = &cobra.Command{
-			Use: debugCmd,
+			Use: promptItem,
 			Run: func(cmd *cobra.Command, args []string) {
 				// TECHDEBT: this is to keep backwards compatibility with localnet
 				configPath = runtime.GetEnv("CONFIG_PATH", "build/config/config1.json")
@@ -124,7 +124,8 @@ func NewDebugSubCommands() []*cobra.Command {
 				if err := p2pMod.Start(); err != nil {
 					logger.Global.Fatal().Err(err).Msg("Failed to start p2p module")
 				}
-				handleSelect(cmd, debugCmd)
+
+				handleSelect(cmd, promptItem)
 			},
 			ValidArgs: items,
 		}

--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -56,15 +56,9 @@ type cliContextKey string
 
 const busCLICtxKey = "bus"
 
-// DISCUSS: Okay so this subcommand is not working when passed as a single command
-// I'm getting an error "server module is not enabled" when I try to run any subcommand
-// But normal debug UI prompt-triggered events are working and do not error
-// I can only think that it's something to do with a context or something that I'm missing.
-
 func init() {
 	dbg := NewDebugCommand()
 	dbg.AddCommand(NewDebugSubCommands()...)
-
 	rootCmd.AddCommand(dbg)
 
 	// by default, we point at the same endpoint used by the CLI but the debug client is used either in docker-compose of K8S, therefore we cater for overriding
@@ -76,8 +70,60 @@ func init() {
 	rpcHost = runtime.GetEnv("RPC_HOST", validator1Endpoint)
 }
 
+// NewDebugCommand returns the cobra CLI for the Debug command.
+func NewDebugCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "debug",
+		Short: "Debug utility for rapid development",
+		Args:  cobra.MaximumNArgs(0),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+
+			// TECHDEBT: this is to keep backwards compatibility with localnet
+			configPath = runtime.GetEnv("CONFIG_PATH", "build/config/config1.json")
+
+			runtimeMgr := runtime.NewManagerFromFiles(
+				configPath, genesisPath,
+				runtime.WithClientDebugMode(),
+				runtime.WithRandomPK(),
+			)
+
+			bus := runtimeMgr.GetBus()
+			modulesRegistry := bus.GetModulesRegistry()
+
+			rpcURL := fmt.Sprintf("http://%s:%s", rpcHost, defaults.DefaultRPCPort)
+
+			addressBookProvider := rpcABP.NewRPCPeerstoreProvider(
+				rpcABP.WithP2PConfig(
+					runtimeMgr.GetConfig().P2P,
+				),
+				rpcABP.WithCustomRPCURL(rpcURL),
+			)
+			modulesRegistry.RegisterModule(addressBookProvider)
+
+			currentHeightProvider := rpcCHP.NewRPCCurrentHeightProvider(
+				rpcCHP.WithCustomRPCURL(rpcURL),
+			)
+			modulesRegistry.RegisterModule(currentHeightProvider)
+
+			setValueInCLIContext(cmd, busCLICtxKey, bus)
+
+			// TECHDEBT: simplify after P2P module consolidation.
+			var err error
+			p2pMod, err = getP2PModule(runtimeMgr)
+			if err != nil {
+				logger.Global.Fatal().Err(err).Msg("Failed to create p2p module")
+			}
+
+			if err := p2pMod.Start(); err != nil {
+				logger.Global.Fatal().Err(err).Msg("Failed to start p2p module")
+			}
+		},
+		RunE: runDebug,
+	}
+}
+
 // NewDebugSubCommands builds out the list of debug subcommands by matching the
-// handleSelect dispatch to the appropriate string.
+// handleSelect dispatch to the appropriate command.
 // * To add a debug subcommand, you must add it to the `items` array and then
 // write a function handler to match for it in `handleSelect`.
 func NewDebugSubCommands() []*cobra.Command {

--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -105,7 +105,7 @@ func NewDebugCommand() *cobra.Command {
 }
 
 // persistentPreRun is called by both debug and debug sub-commands before runs
-func persistentPreRun(cmd *cobra.Command, args []string) {
+func persistentPreRun(cmd *cobra.Command, _ []string) {
 	// TECHDEBT: this is to keep backwards compatibility with localnet
 	configPath = runtime.GetEnv("CONFIG_PATH", "build/config/config1.json")
 

--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -56,9 +56,16 @@ type cliContextKey string
 
 const busCLICtxKey = "bus"
 
+// DISCUSS: Okay so this subcommand is not working when passed as a single command
+// I'm getting an error "server module is not enabled" when I try to run any subcommand
+// But normal debug UI prompt-triggered events are working and do not error
+// I can only think that it's something to do with a context or something that I'm missing.
+
 func init() {
-	debugCmd := NewDebugCommand()
-	rootCmd.AddCommand(debugCmd)
+	dbg := NewDebugCommand()
+	dbg.AddCommand(NewDebugSubCommands()...)
+
+	rootCmd.AddCommand(dbg)
 
 	// by default, we point at the same endpoint used by the CLI but the debug client is used either in docker-compose of K8S, therefore we cater for overriding
 	validator1Endpoint := defaults.Validator1EndpointDockerCompose
@@ -69,11 +76,68 @@ func init() {
 	rpcHost = runtime.GetEnv("RPC_HOST", validator1Endpoint)
 }
 
+// NewDebugSubCommands builds out the list of debug subcommands by matching the
+// handleSelect dispatch to the appropriate string.
+// * To add a debug subcommand, you must add it to the `items` array and then
+// write a function handler to match for it in `handleSelect`.
+func NewDebugSubCommands() []*cobra.Command {
+	commands := make([]*cobra.Command, len(items))
+	for idx, debugCmd := range items {
+		commands[idx] = &cobra.Command{
+			Use: debugCmd,
+			Run: func(cmd *cobra.Command, args []string) {
+				// TECHDEBT: this is to keep backwards compatibility with localnet
+				configPath = runtime.GetEnv("CONFIG_PATH", "build/config/config1.json")
+
+				runtimeMgr := runtime.NewManagerFromFiles(
+					configPath, genesisPath,
+					runtime.WithClientDebugMode(),
+					runtime.WithRandomPK(),
+				)
+
+				bus := runtimeMgr.GetBus()
+				modulesRegistry := bus.GetModulesRegistry()
+				rpcURL := fmt.Sprintf("http://%s:%s", rpcHost, defaults.DefaultRPCPort)
+
+				addressBookProvider := rpcABP.NewRPCPeerstoreProvider(
+					rpcABP.WithP2PConfig(
+						runtimeMgr.GetConfig().P2P,
+					),
+					rpcABP.WithCustomRPCURL(rpcURL),
+				)
+				modulesRegistry.RegisterModule(addressBookProvider)
+
+				currentHeightProvider := rpcCHP.NewRPCCurrentHeightProvider(
+					rpcCHP.WithCustomRPCURL(rpcURL),
+				)
+				modulesRegistry.RegisterModule(currentHeightProvider)
+
+				setValueInCLIContext(cmd, busCLICtxKey, bus)
+
+				// TECHDEBT: simplify after P2P module consolidation.
+				var err error
+				p2pMod, err = getP2PModule(runtimeMgr)
+				if err != nil {
+					logger.Global.Fatal().Err(err).Msg("Failed to create p2p module")
+				}
+
+				if err := p2pMod.Start(); err != nil {
+					logger.Global.Fatal().Err(err).Msg("Failed to start p2p module")
+				}
+				handleSelect(cmd, debugCmd)
+			},
+			ValidArgs: items,
+		}
+	}
+	return commands
+}
+
+// NewDebugCommand returns the cobra CLI for the Debug command.
 func NewDebugCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "debug",
 		Short: "Debug utility for rapid development",
-		Args:  cobra.ExactArgs(0),
+		Args:  cobra.MaximumNArgs(0),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 
 			// TECHDEBT: this is to keep backwards compatibility with localnet

--- a/app/client/doc/CHANGELOG.md
+++ b/app/client/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.29] - 2023-04-25
+
+- Adds debug subcommands matching list of interactive prompt commands
+
 ## [0.0.0.28] - 2023-04-17
 
 - Refactor debug CLI post P2P module re-consolidation

--- a/app/client/doc/CHANGELOG.md
+++ b/app/client/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.29] - 2023-04-25
+## [0.0.0.29] - 2023-04-26
 
 - Adds debug subcommands matching list of interactive prompt commands
 

--- a/app/client/doc/CHANGELOG.md
+++ b/app/client/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.29] - 2023-04-26
+## [0.0.0.29] - 2023-04-28
 
 - Adds debug subcommands matching list of interactive prompt commands
 

--- a/app/client/doc/README.md
+++ b/app/client/doc/README.md
@@ -36,8 +36,7 @@ Command tree available [here](./commands/client.md)
 
 ## Debug Subcommands
 
-The debug command is terminal utility and set of sub-commands for rapid development and debugging of Pocket validators. It is only built in development and testing binaries and is not included in public release versions.
-
+The debug command is terminal utility and set of sub-commands for rapid development and debugging of Pocket validators.
 If `debug` is run with no arguments, it drops the user into an interactive prompt session where they can trigger multiple debug message transmissions from the client binary.
 
 ```bash

--- a/app/client/doc/README.md
+++ b/app/client/doc/README.md
@@ -34,4 +34,45 @@ Command tree available [here](./commands/client.md)
 └── main.go                  # entrypoint
 ```
 
+## Debug Subcommands
+
+The debug command is terminal utility and set of sub-commands for rapid development and debugging of Pocket validators. It is only built in development and testing binaries and is not included in public release versions.
+
+If `debug` is run with no arguments, it drops the user into an interactive prompt session where they can trigger multiple debug message transmissions from the client binary.
+
+```bash
+$> client debug
+[...]
+Use the arrow keys to navigate: ↓ ↑ → ←
+? Select an action:
+  ▸ PrintNodeState (broadcast)
+    TriggerNextView (broadcast)
+    TogglePacemakerMode (broadcast)
+    ResetToGenesis (broadcast)
+    ShowLatestBlockInStore (anycast)
+    MetadataRequest (broadcast)
+    BlockRequest (broadcast)
+
+```
+
+If it's run with an argument it selects the message type that matches that argument.
+The accepted command structure and available sub-commands are shown below.
+
+```bash
+Usage:
+  client debug [flags]      <-- drops you into a debug command prompt
+  client debug [command]    <-- accepts sub commands 
+
+Available Commands:
+  BlockRequest
+  MetadataRequest
+  PrintNodeState
+  ResetToGenesis
+  ShowLatestBlockInStore
+  TogglePacemakerMode
+  TriggerNextView
+```
+
+This allows Pacemaker mode and other functionality to be toggled externally for testing and performance purposes at runtime and not just configured once at start or build time.
+
 <!-- GITHUB_WIKI: app/client/readme -->

--- a/app/docs/CHANGELOG.md
+++ b/app/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.7] - 2023-04-26
+## [0.0.0.7] - 2023-04-28
 
 - Adds debug sub-commands to the debug CLI and appropriate documentation
 

--- a/app/docs/CHANGELOG.md
+++ b/app/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.7] - 2023-04-11
+## [0.0.0.7] - 2023-04-26
 
 - Adds debug sub-commands to the debug CLI and appropriate documentation
 

--- a/app/docs/CHANGELOG.md
+++ b/app/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.6] - 2023-04-11
+## [0.0.0.7] - 2023-04-11
 
 - Adds debug sub-commands to the debug CLI and appropriate documentation
 

--- a/app/docs/CHANGELOG.md
+++ b/app/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.6] - 2023-04-11
+
+- Adds debug sub-commands to the debug CLI and appropriate documentation
+
 ## [0.0.0.6] - 2023-04-10
 
 - Makes Account sub-command respect non-interactive flag


### PR DESCRIPTION
## Description

This PR creates a sub-command in the debug CLI for every item in the interactive prompt list. This enables E2E tests to create more scenarios for testing and assertion.

## Issue

Fixes #661 

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Builds out a list of subcommands from the list of prompt UI commands.

## Testing

- [x] `make localnet_client_debug` should produce a terminal prompt and all sub-commands should run the same as terminal prompt commands.
- [x] `make develop_test`; if any code changes were made
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
