### PR TITLE
Update devlog5.md

### DIFF
--- a/docs/devlog/devlog5.md
+++ b/docs/devlog/devlog5.md
@@ -106,4 +106,4 @@ Pocket Network is a blockchain data platform, built for applications, that uses 
 - [Discord](https://discord.gg/pokt)
 - [Twitter](https://twitter.com/POKTnetwork)
 
-<!-- GITHUB_WIKI: devlog/2023_03_09 -->
+<!-- GITHUB_WIKI: devlog/2023_03_21 -->


### PR DESCRIPTION
Avoid the `GITHUB_WIKI` tag in devlog5 so it updates in our [wiki](https://github.com/pokt-network/pocket/wiki) correctly.

There is currently a duplicate tag error on main.

![Screenshot 2023-04-12 at 3 01 37 PM](https://user-images.githubusercontent.com/1892194/231595593-ff2e3f79-5f53-4d48-a440-19770d76491f.png)
