### PR TITLE
[Peristence] Fix `TxIndexer` to index sender and recipient transactions with height and index suffixes

### DIFF
--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.49] - 2023-04-14
+
+- Index transactions in the `TxIndexer` by sender and recipient using the height and block index of the transactions
+
 ## [0.0.0.48] - 2023-04-13
 
 - Remove persistent specific `TxResult` protobuf and interface

--- a/persistence/indexer/indexer.go
+++ b/persistence/indexer/indexer.go
@@ -83,10 +83,10 @@ func (indexer *txIndexer) Index(result *coreTypes.TxResult) error {
 	if err := indexer.indexByHeightAndIndex(result.GetHeight(), result.GetIndex(), hashKey); err != nil {
 		return err
 	}
-	if err := indexer.indexBySenderHeightAndIndex(result.GetSignerAddr(), result.GetHeight(), result.GetIndex(), hashKey); err != nil {
+	if err := indexer.indexBySenderHeightAndBlockIndex(result.GetSignerAddr(), result.GetHeight(), result.GetIndex(), hashKey); err != nil {
 		return err
 	}
-	if err := indexer.indexByRecipientHeightAndIndex(result.GetRecipientAddr(), result.GetHeight(), result.GetIndex(), hashKey); err != nil {
+	if err := indexer.indexByRecipientHeightAndBlockIndex(result.GetRecipientAddr(), result.GetHeight(), result.GetIndex(), hashKey); err != nil {
 		return err
 	}
 	return nil
@@ -148,15 +148,18 @@ func (indexer *txIndexer) indexByHeightAndIndex(height int64, index int32, bz []
 	return indexer.db.Set(indexer.heightAndIndexKey(height, index), bz)
 }
 
-func (indexer *txIndexer) indexBySenderHeightAndIndex(sender string, height int64, index int32, bz []byte) error {
-	return indexer.db.Set(indexer.senderHeightAndIndexKey(sender, height, index), bz)
+func (indexer *txIndexer) indexBySenderHeightAndBlockIndex(sender string, height int64, blockIndex int32, bz []byte) error {
+	if sender == "" {
+		return nil
+	}
+	return indexer.db.Set(indexer.senderHeightAndBlockIndexKey(sender, height, blockIndex), bz)
 }
 
-func (indexer *txIndexer) indexByRecipientHeightAndIndex(recipient string, height int64, index int32, bz []byte) error {
+func (indexer *txIndexer) indexByRecipientHeightAndBlockIndex(recipient string, height int64, blockIndex int32, bz []byte) error {
 	if recipient == "" {
 		return nil
 	}
-	return indexer.db.Set(indexer.recipientHeightAndIndexKey(recipient, height, index), bz)
+	return indexer.db.Set(indexer.recipientHeightAndBlockIndexKey(recipient, height, blockIndex), bz)
 }
 
 // key helper functions
@@ -177,10 +180,10 @@ func (indexer *txIndexer) senderKey(address string) []byte {
 	return indexer.key(senderPrefix, address+"/")
 }
 
-func (indexer *txIndexer) senderHeightAndIndexKey(address string, height int64, index int32) []byte {
+func (indexer *txIndexer) senderHeightAndBlockIndexKey(address string, height int64, blockIndex int32) []byte {
 	key := indexer.senderKey(address)
 	key = append(key, []byte(elenEncoder.EncodeInt(int(height))+"/")...)
-	key = append(key, []byte(elenEncoder.EncodeInt(int(index)))...)
+	key = append(key, []byte(elenEncoder.EncodeInt(int(blockIndex)))...)
 	return key
 }
 
@@ -188,10 +191,10 @@ func (indexer *txIndexer) recipientKey(address string) []byte {
 	return indexer.key(recipientPrefix, address+"/")
 }
 
-func (indexer *txIndexer) recipientHeightAndIndexKey(address string, height int64, index int32) []byte {
+func (indexer *txIndexer) recipientHeightAndBlockIndexKey(address string, height int64, blockIndex int32) []byte {
 	key := indexer.recipientKey(address)
 	key = append(key, []byte(elenEncoder.EncodeInt(int(height))+"/")...)
-	key = append(key, []byte(elenEncoder.EncodeInt(int(index)))...)
+	key = append(key, []byte(elenEncoder.EncodeInt(int(blockIndex)))...)
 	return key
 }
 

--- a/persistence/indexer/indexer.go
+++ b/persistence/indexer/indexer.go
@@ -83,10 +83,10 @@ func (indexer *txIndexer) Index(result *coreTypes.TxResult) error {
 	if err := indexer.indexByHeightAndIndex(result.GetHeight(), result.GetIndex(), hashKey); err != nil {
 		return err
 	}
-	if err := indexer.indexBySender(result.GetSignerAddr(), hashKey); err != nil {
+	if err := indexer.indexBySenderHeightAndIndex(result.GetSignerAddr(), result.GetHeight(), result.GetIndex(), hashKey); err != nil {
 		return err
 	}
-	if err := indexer.indexByRecipient(result.GetRecipientAddr(), hashKey); err != nil {
+	if err := indexer.indexByRecipientHeightAndIndex(result.GetRecipientAddr(), result.GetHeight(), result.GetIndex(), hashKey); err != nil {
 		return err
 	}
 	return nil
@@ -148,15 +148,15 @@ func (indexer *txIndexer) indexByHeightAndIndex(height int64, index int32, bz []
 	return indexer.db.Set(indexer.heightAndIndexKey(height, index), bz)
 }
 
-func (indexer *txIndexer) indexBySender(sender string, bz []byte) error {
-	return indexer.db.Set(indexer.senderKey(sender), bz)
+func (indexer *txIndexer) indexBySenderHeightAndIndex(sender string, height int64, index int32, bz []byte) error {
+	return indexer.db.Set(indexer.senderHeightAndIndexKey(sender, height, index), bz)
 }
 
-func (indexer *txIndexer) indexByRecipient(recipient string, bz []byte) error {
+func (indexer *txIndexer) indexByRecipientHeightAndIndex(recipient string, height int64, index int32, bz []byte) error {
 	if recipient == "" {
 		return nil
 	}
-	return indexer.db.Set(indexer.recipientKey(recipient), bz)
+	return indexer.db.Set(indexer.recipientHeightAndIndexKey(recipient, height, index), bz)
 }
 
 // key helper functions
@@ -174,11 +174,25 @@ func (indexer *txIndexer) heightKey(height int64) []byte {
 }
 
 func (indexer *txIndexer) senderKey(address string) []byte {
-	return indexer.key(senderPrefix, address)
+	return indexer.key(senderPrefix, address+"/")
+}
+
+func (indexer *txIndexer) senderHeightAndIndexKey(address string, height int64, index int32) []byte {
+	key := indexer.senderKey(address)
+	key = append(key, []byte(elenEncoder.EncodeInt(int(height))+"/")...)
+	key = append(key, []byte(elenEncoder.EncodeInt(int(index)))...)
+	return key
 }
 
 func (indexer *txIndexer) recipientKey(address string) []byte {
-	return indexer.key(recipientPrefix, address)
+	return indexer.key(recipientPrefix, address+"/")
+}
+
+func (indexer *txIndexer) recipientHeightAndIndexKey(address string, height int64, index int32) []byte {
+	key := indexer.recipientKey(address)
+	key = append(key, []byte(elenEncoder.EncodeInt(int(height))+"/")...)
+	key = append(key, []byte(elenEncoder.EncodeInt(int(index)))...)
+	return key
 }
 
 func (indexer *txIndexer) key(prefix rune, postfix string) []byte {


### PR DESCRIPTION
## Description

This PR fixes the `TxIndexer` so that it can index multiple transactions by sender and recipient instead of simply overwriting the previous transaction.

By adding the height and index of the index as a suffix to the key when storing the transaction bytes in the TxIndexer KVStore, we can now query all transactions sent or received by a specific address, through the TxIndexer.

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Index by Sender and Recipient with height and index suffixes

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
