### PR TITLE
Update e2e/docs/CHANGELOG.md

### DIFF
--- a/e2e/docs/CHANGELOG.md
+++ b/e2e/docs/CHANGELOG.md
@@ -28,4 +28,4 @@ Adds Stake, Unstake, & Send Tests [#653](https://github.com/pokt-network/pocket/
 
 Hello Changelog
 
-<!-- GITHUB_WIKI: changelog/build -->
+<!-- GITHUB_WIKI: changelog/e2e -->


### PR DESCRIPTION
Avoid duplication of wiki path. Currently fails CI run on main branch: [example](https://github.com/pokt-network/pocket/actions/runs/4703904314/jobs/8342968492).