### PR TITLE
Fix cluster manager with LocalNet on Helm charts

### DIFF
--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.36] - 2023-04-17
+## [0.0.0.36] - 2023-04-18
 
 - Changed the way `cluster-manager` looks up the new validators to be staked.
 

--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.36] - 2023-04-18
+## [0.0.0.36] - 2023-04-19
 
 - Changed the way `cluster-manager` looks up the new validators to be staked.
 

--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.36] - 2023-04-17
+
+- Changed the way `cluster-manager` looks up the new validators to be staked.
+
 ## [0.0.0.35] - 2023-04-17
 
 - Removed runtime/configs.Config#UseLibp2p field

--- a/build/localnet/cluster-manager/main.go
+++ b/build/localnet/cluster-manager/main.go
@@ -66,11 +66,7 @@ func main() {
 			continue
 		}
 
-		// logger.Info().Str("validator", service.Name).Msg("Validator event")
-		// logger.Info().Str("validatorKeysMap", string(validatorKeysMap)).Msg("Validator event")
-
 		validatorId := extractValidatorId(service.Name)
-		logger.Info().Str("validator", service.Name).Str("validatorId", validatorId).Msg("Validator event")
 		privateKey := getPrivateKey(validatorKeysMap, validatorId)
 
 		switch event.Type {

--- a/build/localnet/cluster-manager/main.go
+++ b/build/localnet/cluster-manager/main.go
@@ -20,6 +20,7 @@ import (
 )
 
 const cliPath = "/usr/local/bin/client"
+const validatorServiceUrlFormat = "validator-%s-pocket-validator:%d"
 
 var (
 	rpcURL string
@@ -33,7 +34,7 @@ var (
 )
 
 func init() {
-	rpcURL = fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", "validator-001-pocket-validator"), defaults.DefaultRPCPort)
+	rpcURL = fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", defaults.Validator1EndpointK8S), defaults.DefaultRPCPort)
 }
 
 func main() {
@@ -77,7 +78,7 @@ func main() {
 				continue
 			}
 
-			validatorServiceUrl := fmt.Sprintf("validator-%s-pocket-validator:%d", validatorId, defaults.DefaultP2PPort)
+			validatorServiceUrl := fmt.Sprintf(validatorServiceUrlFormat, validatorId, defaults.DefaultP2PPort)
 			if err := stakeValidator(privateKey, autoStakeAmount, autoStakeChains, validatorServiceUrl); err != nil {
 				logger.Err(err).Msg("Error staking validator")
 			}

--- a/build/localnet/cluster-manager/main.go
+++ b/build/localnet/cluster-manager/main.go
@@ -33,7 +33,7 @@ var (
 )
 
 func init() {
-	rpcURL = fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", "v1-validator001"), defaults.DefaultRPCPort)
+	rpcURL = fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", "validator-001-pocket-validator"), defaults.DefaultRPCPort)
 }
 
 func main() {
@@ -66,7 +66,11 @@ func main() {
 			continue
 		}
 
+		// logger.Info().Str("validator", service.Name).Msg("Validator event")
+		// logger.Info().Str("validatorKeysMap", string(validatorKeysMap)).Msg("Validator event")
+
 		validatorId := extractValidatorId(service.Name)
+		logger.Info().Str("validator", service.Name).Str("validatorId", validatorId).Msg("Validator event")
 		privateKey := getPrivateKey(validatorKeysMap, validatorId)
 
 		switch event.Type {
@@ -77,7 +81,7 @@ func main() {
 				continue
 			}
 
-			validatorServiceUrl := fmt.Sprintf("v1-validator%s:%d", validatorId, defaults.DefaultP2PPort)
+			validatorServiceUrl := fmt.Sprintf("validator-%s-pocket-validator:%d", validatorId, defaults.DefaultP2PPort)
 			if err := stakeValidator(privateKey, autoStakeAmount, autoStakeChains, validatorServiceUrl); err != nil {
 				logger.Err(err).Msg("Error staking validator")
 			}

--- a/build/localnet/cluster-manager/utils.go
+++ b/build/localnet/cluster-manager/utils.go
@@ -1,20 +1,23 @@
 package main
 
 import (
+	"regexp"
+
 	cryptoPocket "github.com/pokt-network/pocket/shared/crypto"
 	v1 "k8s.io/api/core/v1"
 )
 
 func isValidator(service *v1.Service) bool {
-	return service.Labels["v1-purpose"] == "validator"
+	return service.Labels["pokt.network/purpose"] == "validator"
 }
 
-// extractValidatorId extracts the validator id from the validator name (e.g. v1-validator001 -> 001)
+// extractValidatorId extracts the validator id from the validator name (e.g. validator-001-pocket-validator -> 001)
 //
-// it follows the pattern defined in the v1-validator template (/build/localnet/templates/v1-validator-template.yaml.tpl)
+// it follows the pattern defined in the pocket helm chart.
 func extractValidatorId(validatorName string) string {
 	if len(validatorName) >= 3 {
-		return validatorName[len(validatorName)-3:]
+		re := regexp.MustCompile(`validator-(\d+)-pocket-validator`)
+		return re.FindStringSubmatch(validatorName)[1]
 	}
 	return validatorName
 }

--- a/runtime/defaults/defaults.go
+++ b/runtime/defaults/defaults.go
@@ -27,7 +27,7 @@ const (
 	DefaultBusBufferSize            = 100
 	DefaultRPCHost                  = "localhost"
 	Validator1EndpointDockerCompose = "node1.consensus"
-	Validator1EndpointK8S           = "v1-validator001"
+	Validator1EndpointK8S           = "validator-001-pocket-validator"
 )
 
 var (

--- a/runtime/docs/CHANGELOG.md
+++ b/runtime/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.34] - 2023-04-17
+
+- Changed `Validator1EndpointK8S` which now reflects the new value.
+
 ## [0.0.0.33] - 2023-04-17
 
 - Removed `runtime/configs.Config#UseLibp2p` field

--- a/runtime/docs/CHANGELOG.md
+++ b/runtime/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.34] - 2023-04-17
+## [0.0.0.34] - 2023-04-19
 
 - Changed `Validator1EndpointK8S` which now reflects the new value.
 


### PR DESCRIPTION
## Description

After we switched to Helm charts on LocalNet, the cluster manager stopped automatically staking validators beyond four pre-staked validators.

## Type of change

Please mark the relevant option(s):

- [x] Bug fix

## List of changes

- Change the way cluster manager looks up validator to stake automatically.

## Testing

- [ ] `make develop_test`; if any code changes were made
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
