### PR TITLE
[Testing (DUP)] Add /internal/testutil pkg & refactor mockdns test code

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -30,7 +30,7 @@ then
 fi
 
 # Initialise arrays and script wide variables
-IGNORE_DIRS=(".github" ".githooks" "docs" "bin")
+IGNORE_DIRS=(".github" ".githooks" "docs" "bin" "internal")
 MODULES_EDITED=() # Modules are considered top-level directories directly under root
 MODULES_MISSING_CHANGELOG=()
 CHANGELOG_FILES=() # Full paths to CHANGELOG.md files

--- a/.githooks/pre-receive
+++ b/.githooks/pre-receive
@@ -4,7 +4,7 @@
 BRANCH_CHANGED_FILES=($@)
 
 # Initialise arrays and script wide variables
-IGNORE_DIRS=(".github" ".githooks" "docs" "bin")
+IGNORE_DIRS=(".github" ".githooks" "docs" "bin" "internal")
 MODULES_EDITED=() # Modules are considered top-level directories directly under root
 MODULES_MISSING_CHANGELOG=()
 CHANGELOG_FILES=() # Full paths to CHANGELOG.md files

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -279,6 +279,8 @@ Pocket
 │   ├── docs                          # Links to V1 Protocol implementation documentation (excluding the protocol specification)
 ├── consensus                         # Implementation of the Consensus module
 ├── docs                              # Links to V1 Protocol implementation documentation (excluding the protocol specification)
+├── internal                          # Internal package following the convention established in Go 1.4: https://go.dev/doc/go1.4#internalpackages
+│   └── testutil                      # Internal package for reusable and/or common test code
 ├── logger                            # Implementation of the Logger module
 ├── p2p                               # Implementation of the P2P module
 ├── persistence                       # Implementation of the Persistence module

--- a/internal/testutil/mockdns.go
+++ b/internal/testutil/mockdns.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/foxcpp/go-mockdns"
+	"github.com/stretchr/testify/require"
+)
+
+func PrepareDNSMockFromServiceURLs(t *testing.T, serviceURLs []string) (done func()) {
+	zones := make(map[string]mockdns.Zone)
+	for i, u := range serviceURLs {
+		// Perpend `scheme://` as serviceURLs are currently scheme-less.
+		// Required for parsing to produce useful results.
+		// (see: https://pkg.go.dev/net/url@go1.20.2#URL)
+		serviceURL, err := url.Parse(fmt.Sprintf("scheme://%s", u))
+		require.NoError(t, err)
+
+		ipStr := fmt.Sprintf("10.0.0.%d", i+1)
+
+		if i >= 254 {
+			panic(fmt.Sprintf("would generate invalid IPv4 address: %s", ipStr))
+		}
+
+		zones[fmt.Sprintf("%s.", serviceURL.Hostname())] = mockdns.Zone{
+			A: []string{ipStr},
+		}
+	}
+
+	return PrepareDNSMock(zones)
+}
+
+func PrepareDNSMock(zones map[string]mockdns.Zone) (done func()) {
+	srv, _ := mockdns.NewServerWithLogger(zones, noopLogger{}, false)
+	srv.PatchNet(net.DefaultResolver)
+	return func() {
+		_ = srv.Close()
+		mockdns.UnpatchNet(net.DefaultResolver)
+	}
+}
+
+// NB: default logging behavior is too noisy.
+// noopLogger implements go-mockdns's `mockdns.Logger` interface.
+type noopLogger struct{}
+
+func (nl noopLogger) Printf(format string, args ...interface{}) {
+	// noop
+}

--- a/p2p/CHANGELOG.md
+++ b/p2p/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.44] - 2023-04-20
+
+- Refactor `mockdns` test helpers
+
 ## [0.0.0.43] - 2023-04-17
 
 - Add test to exercise `sortedPeersView#Add()` and `#Remove()`

--- a/p2p/module_raintree_test.go
+++ b/p2p/module_raintree_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/pokt-network/pocket/internal/testutil"
 	"github.com/pokt-network/pocket/p2p/protocol"
 )
 
@@ -233,7 +234,7 @@ func testRainTreeCalls(t *testing.T, origNode string, networkSimulationConfig Te
 		return iId < jId
 	})
 
-	prepareDNSResolverMock(t, valIds)
+	testutil.PrepareDNSMockFromServiceURLs(t, valIds)
 
 	// Create connection and bus mocks along with a shared WaitGroup to track the number of expected
 	// reads and writes throughout the mocked local network

--- a/p2p/raintree/peers_manager_test.go
+++ b/p2p/raintree/peers_manager_test.go
@@ -3,7 +3,6 @@ package raintree
 import (
 	"encoding/hex"
 	"fmt"
-	"net"
 	"net/url"
 	"strings"
 	"testing"
@@ -14,6 +13,7 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pokt-network/pocket/internal/testutil"
 	typesP2P "github.com/pokt-network/pocket/p2p/types"
 	mocksP2P "github.com/pokt-network/pocket/p2p/types/mocks"
 	"github.com/pokt-network/pocket/runtime/configs"
@@ -354,22 +354,6 @@ func mockAlphabetValidatorServiceURLsDNS(t *testing.T) (done func()) {
 			A: []string{fmt.Sprintf("10.0.0.%d", i+1)},
 		}
 	}
-	return prepareDNSMock(zones)
-}
 
-// TECHDEBT(#609): de-duplicate / refactor `prepaand reDNSMock` & `noopLogger`.
-func prepareDNSMock(zones map[string]mockdns.Zone) (done func()) {
-	srv, _ := mockdns.NewServerWithLogger(zones, noopLogger{}, false)
-	srv.PatchNet(net.DefaultResolver)
-	return func() {
-		_ = srv.Close()
-		mockdns.UnpatchNet(net.DefaultResolver)
-	}
-}
-
-// noopLogger implements go-mockdns's `mockdns.Logger` interface.
-type noopLogger struct{}
-
-func (nl noopLogger) Printf(format string, args ...interface{}) {
-	// noop
+	return testutil.PrepareDNSMock(zones)
 }

--- a/p2p/utils_test.go
+++ b/p2p/utils_test.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/url"
 	"sort"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/foxcpp/go-mockdns"
 	"github.com/golang/mock/gomock"
 	libp2pCrypto "github.com/libp2p/go-libp2p/core/crypto"
 	libp2pPeer "github.com/libp2p/go-libp2p/core/peer"
@@ -142,45 +140,6 @@ func setupMockNetPeers(t *testing.T, netMock mocknet.Mocknet, numPeers int) (pee
 	require.NoError(t, err)
 
 	return peerIDs
-}
-
-// TECHDEBT(#609): this is one of a few places where we could de-duplicate test
-// code if we had a conventional place to store packages intended for import
-// only into tests.
-func prepareDNSResolverMock(t *testing.T, serviceURLs []string) (done func()) {
-	zones := make(map[string]mockdns.Zone)
-	for i, u := range serviceURLs {
-		// Perpend `scheme://` as serviceURLs are currently scheme-less.
-		// Required for parsing to produce useful results.
-		// (see: https://pkg.go.dev/net/url@go1.20.2#URL)
-		serviceURL, err := url.Parse(fmt.Sprintf("scheme://%s", u))
-		require.NoError(t, err)
-
-		ipStr := fmt.Sprintf("10.0.0.%d", i+1)
-
-		if i >= 254 {
-			panic(fmt.Sprintf("would generate invalid IPv4 address: %s", ipStr))
-		}
-
-		zones[fmt.Sprintf("%s.", serviceURL.Hostname())] = mockdns.Zone{
-			A: []string{ipStr},
-		}
-	}
-
-	srv, _ := mockdns.NewServerWithLogger(zones, noopLogger{}, false)
-	srv.PatchNet(net.DefaultResolver)
-	return func() {
-		_ = srv.Close()
-		mockdns.UnpatchNet(net.DefaultResolver)
-	}
-}
-
-// NB: default logging behavior is too noisy.
-// noopLogger implements go-mockdns's `mockdns.Logger` interface.
-type noopLogger struct{}
-
-func (nl noopLogger) Printf(format string, args ...interface{}) {
-	// noop
 }
 
 // createMockRuntimeMgrs creates `numValidators` instances of mocked `RuntimeMgr` that are essentially


### PR DESCRIPTION
## Description

Factors out some common mockdns usage, including a "noop" logger to things down (mockdns is noisy IMO).

(Duplicate of #685 :roll_eyes:, I forgot to change the base branch before merging. As a result, the changes were squashed-merged into a different branch than main. Re-opening here, apologies for the extra noise. :pray::pray:)

## Issue

Fixes #609

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Create `/internal` directory
- Add `/interal/testutil` pkg
- Refactor existing `mockdns` usage

## Testing

- [x] Ensure test util package members are not present in symbol table of non-test builds:
  1. `go build -o ./pokt-node ./app/pocket`
  2. `nm ./pokt-node | grep prepareDNSResolverMock` should print nothing
      If `prepareDNSResolverMock` was included in the build, it will be listed in the symbol table which we can print with `nm`. **Double-check the function names match, a typo could result in a false positive**. Additionally, one can build a test binary (`go test -c -o <output bin path> [-run <test func name>] <pkg>`) on a test pkg which is known to import a test util function and ensure that it is present in the symbol table, as a control.

![image](https://user-images.githubusercontent.com/600733/232450913-0e5c35ad-7734-404c-a563-d10a7b6f00b9.png)


- [ ] `make develop_test`; if any code changes were made
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
