### PR TITLE
[Makefile] fixes the localnet_db_cli target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,9 +517,9 @@ localnet_down: ## Stops LocalNet and cleans up dependencies (tl;dr `tilt down`)
 	tilt down --file=build/localnet/Tiltfile
 
 .PHONY: localnet_db_cli
-localnet_db_cli: ## Open a CLI to the local containerized postgres instancedb_cli:
+localnet_db_cli: ## Open a CLI to the local containerized postgres instance of validator 001:
 	echo "View schema by running 'SELECT schema_name FROM information_schema.schemata;'"
-	kubectl exec -it services/dependencies-postgresql -- bash -c "psql postgresql://postgres:LocalNetPassword@localhost"
+	kubectl exec -it validator-001-postgresql-0 -- bash -c "psql postgresql://postgres:LocalNetPassword@localhost"
 
 .PHONY: check_cross_module_imports
 check_cross_module_imports: ## Lists cross-module imports

--- a/Makefile
+++ b/Makefile
@@ -506,11 +506,11 @@ localnet_shell: ## Opens a shell in the pod that has the `client` cli available.
 
 .PHONY: localnet_logs_validators
 localnet_logs_validators: ## Outputs logs from all validators
-	kubectl logs -l v1-purpose=validator --all-containers=true --tail=-1
+	kubectl logs -l "pokt.network/purpose=validator" --all-containers=true --tail=-1
 
 .PHONY: localnet_logs_validators_follow
 localnet_logs_validators_follow: ## Outputs logs from all validators and follows them (i.e. tail)
-	kubectl logs -l v1-purpose=validator --all-containers=true --max-log-requests=1000 --tail=-1 -f
+	kubectl logs -l "pokt.network/purpose=validator" --all-containers=true --max-log-requests=1000 --tail=-1 -f
 
 .PHONY: localnet_down
 localnet_down: ## Stops LocalNet and cleans up dependencies (tl;dr `tilt down`)


### PR DESCRIPTION
## Description

#658 changed how Postgres instances are handled and assigned to Validators in the LocalNet, which broke the Make target specified for grabbing a shell to the LocalNet database. This PR fixes the command to target the Postgres instance for validator-001 by default, since validator-001 used for other tasks by default.

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Changes `make localnet_db_cli` to target the Postgres instance that `validator001` uses.

## Testing

- [ ] `make develop_test`; if any code changes were made
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
