### PR TITLE
[E2E] Standardize Kube pod name across DevNet and LocalNet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ localnet_client_debug: ## Opens a `client debug` cli to interact with blockchain
 
 .PHONY: localnet_shell
 localnet_shell: ## Opens a shell in the pod that has the `client` cli available. The binary updates automatically whenever the code changes (i.e. hot reloads).
-	kubectl exec -it deploy/pocket-v1-cli-client --container pocket -- /bin/bash
+	kubectl exec -it deploy/dev-cli-client --container pocket -- /bin/bash
 
 .PHONY: localnet_logs_validators
 localnet_logs_validators: ## Outputs logs from all validators

--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ localnet_up: ## Starts up a k8s LocalNet with all necessary dependencies (tl;dr 
 
 .PHONY: localnet_client_debug
 localnet_client_debug: ## Opens a `client debug` cli to interact with blockchain (e.g. change pacemaker mode, reset to genesis, etc). Though the node binary updates automatiacally on every code change (i.e. hot reloads), if client is already open you need to re-run this command to execute freshly compiled binary.
-	kubectl exec -it deploy/pocket-v1-cli-client --container pocket -- client debug
+	kubectl exec -it deploy/dev-cli-client --container pocket -- client debug
 
 .PHONY: localnet_shell
 localnet_shell: ## Opens a shell in the pod that has the `client` cli available. The binary updates automatically whenever the code changes (i.e. hot reloads).

--- a/build/localnet/Tiltfile
+++ b/build/localnet/Tiltfile
@@ -155,7 +155,7 @@ k8s_yaml(
 )
 
 k8s_yaml(["manifests/cli-client.yaml"])
-k8s_resource('pocket-v1-cli-client', labels=['client'])
+k8s_resource('deploy/dev-cli-client', labels=['client'])
 k8s_yaml(['manifests/cluster-manager.yaml'])
 k8s_resource('pocket-v1-cluster-manager', labels=['cluster-manager'])
 

--- a/build/localnet/Tiltfile
+++ b/build/localnet/Tiltfile
@@ -155,7 +155,7 @@ k8s_yaml(
 )
 
 k8s_yaml(["manifests/cli-client.yaml"])
-k8s_resource('deploy/dev-cli-client', labels=['client'])
+k8s_resource('dev-cli-client', labels=['client'])
 k8s_yaml(['manifests/cluster-manager.yaml'])
 k8s_resource('pocket-v1-cluster-manager', labels=['cluster-manager'])
 

--- a/build/localnet/manifests/cli-client.yaml
+++ b/build/localnet/manifests/cli-client.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pocket-v1-cli-client
+  name: dev-cli-client
   namespace: default
   labels:
     app: v1-cli-client
@@ -99,12 +99,12 @@ spec:
             defaultMode: 420
         - name: datadir
           persistentVolumeClaim:
-            claimName: pocket-v1-cli-client-datadir
+            claimName: dev-cli-client-datadir
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: pocket-v1-cli-client-datadir
+  name: dev-cli-client-datadir
 spec:
   accessModes:
     - ReadWriteOnce

--- a/e2e/docs/CHANGELOG.md
+++ b/e2e/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.6] - 2023-04-26
+
+- Standardizes the kube pod name that E2E tests use
+
 ## [0.0.0.5] - 2023-04-24
 
 - Attempts to fetch an in-cluster kubeconfig for E2E tests if none is found in `$HOME/.kube`

--- a/e2e/tests/validator.go
+++ b/e2e/tests/validator.go
@@ -10,8 +10,12 @@ import (
 	"github.com/pokt-network/pocket/runtime/defaults"
 )
 
-// rpcURL of the pod that the test harness drives
-var rpcURL string
+var (
+	// rpcURL of the pod that the test harness drives
+	rpcURL string
+	// targetPod is the kube pod that drives E2E tests
+	targetPod = "deploy/dev-cli-client"
+)
 
 func init() {
 	rpcURL = fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", "pocket-validators"), defaults.DefaultRPCPort)
@@ -40,10 +44,10 @@ type validatorPod struct {
 	result *commandResult // stores the result of the last command that was run
 }
 
-// RunCommand runs a command on the pocket binary
+// RunCommand runs a command on a target kube pod
 func (v *validatorPod) RunCommand(args ...string) (*commandResult, error) {
 	base := []string{
-		"exec", "-i", "deploy/pocket-v1-cli-client",
+		"exec", "-i", targetPod,
 		"--container", "pocket",
 		"--", cliPath,
 		"--non_interactive=true",

--- a/e2e/tests/validator.go
+++ b/e2e/tests/validator.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	// rpcURL of the pod that the test harness drives
+	// rpcURL used by targetPod to build commands
 	rpcURL string
-	// targetPod is the kube pod that drives E2E tests
+	// targetPod is the kube pod that executes calls to the pocket binary under test
 	targetPod = "deploy/dev-cli-client"
 )
 


### PR DESCRIPTION
## Description

This PR adjusts the names of the Kube  pod used in LocalNet to match its counterpart in DevNet for E2E testing and other cross-environment needs.

See [cli-client.yaml](https://github.com/pokt-network/protocol-infra/blob/main/charts/v1-network-base/templates/cli-client.yaml) for the exact manifest.

## Issue

Related to #581 & #582 

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [x] Unifomity

## List of changes

- Renames the local deploy of the CLI client to match the [same name that DevNet deploys](https://github.com/pokt-network/protocol-infra/blob/main/charts/v1-network-base/templates/cli-client.yaml). 

## Testing

- [x] `make develop_test`; if any code changes were made
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
