### PR TITLE
[Persistence] Refactors BlockStore

### DIFF
--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.51] - 2023-05-011
+## [0.0.0.51] - 2023-05-012
 
 - Updates consensus test to use BlockStore mock instead of KVStore mock
 

--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.51] - 2023-05-011
+
+- Updates consensus test to use BlockStore mock instead of KVStore mock
+
 ## [0.0.0.50] - 2023-05-03
 
 - Rename `TxResult` to `IndexedTransaction`

--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.51] - 2023-05-012
+## [0.0.0.51] - 2023-05-16
 
 - Updates consensus test to use BlockStore mock instead of KVStore mock
 

--- a/consensus/e2e_tests/utils_test.go
+++ b/consensus/e2e_tests/utils_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pokt-network/pocket/consensus"
 	typesCons "github.com/pokt-network/pocket/consensus/types"
-	mocksPer "github.com/pokt-network/pocket/persistence/types/mocks"
+	blockstoreMocks "github.com/pokt-network/pocket/persistence/types/mocks/blockstore"
 	"github.com/pokt-network/pocket/runtime"
 	"github.com/pokt-network/pocket/runtime/configs"
 	"github.com/pokt-network/pocket/runtime/defaults"
@@ -22,7 +22,6 @@ import (
 	"github.com/pokt-network/pocket/shared"
 	"github.com/pokt-network/pocket/shared/codec"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
-	"github.com/pokt-network/pocket/shared/crypto"
 	cryptoPocket "github.com/pokt-network/pocket/shared/crypto"
 	"github.com/pokt-network/pocket/shared/messaging"
 	"github.com/pokt-network/pocket/shared/modules"
@@ -373,7 +372,7 @@ func basePersistenceMock(t *testing.T, _ modules.EventsChannel, bus modules.Bus)
 
 	persistenceMock.EXPECT().ReleaseWriteContext().Return(nil).AnyTimes()
 
-	blockStoreMock := mocksPer.NewMockKVStore(ctrl)
+	blockStoreMock := blockstoreMocks.NewMockBlockStore(ctrl)
 
 	blockStoreMock.EXPECT().Get(gomock.Any()).DoAndReturn(func(height []byte) ([]byte, error) {
 		heightInt := utils.HeightFromBytes(height)
@@ -737,7 +736,7 @@ func waitForNodeToCatchUp(
 	return nil
 }
 
-func generatePlaceholderBlock(height uint64, leaderAddrr crypto.Address) *coreTypes.Block {
+func generatePlaceholderBlock(height uint64, leaderAddrr cryptoPocket.Address) *coreTypes.Block {
 	blockHeader := &coreTypes.BlockHeader{
 		Height:            height,
 		StateHash:         stateHash,

--- a/consensus/e2e_tests/utils_test.go
+++ b/consensus/e2e_tests/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pokt-network/pocket/shared"
 	"github.com/pokt-network/pocket/shared/codec"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
+	"github.com/pokt-network/pocket/shared/crypto"
 	cryptoPocket "github.com/pokt-network/pocket/shared/crypto"
 	"github.com/pokt-network/pocket/shared/messaging"
 	"github.com/pokt-network/pocket/shared/modules"
@@ -736,7 +737,7 @@ func waitForNodeToCatchUp(
 	return nil
 }
 
-func generatePlaceholderBlock(height uint64, leaderAddrr cryptoPocket.Address) *coreTypes.Block {
+func generatePlaceholderBlock(height uint64, leaderAddrr crypto.Address) *coreTypes.Block {
 	blockHeader := &coreTypes.BlockHeader{
 		Height:            height,
 		StateHash:         stateHash,

--- a/persistence/blockstore/block_store.go
+++ b/persistence/blockstore/block_store.go
@@ -1,5 +1,7 @@
 package blockstore
 
+//go:generate mockgen -source=$GOFILE -destination=../types/mocks/block_store_mock.go github.com/pokt-network/pocket/persistence/types BlockStore
+
 import (
 	"fmt"
 

--- a/persistence/blockstore/block_store.go
+++ b/persistence/blockstore/block_store.go
@@ -7,6 +7,8 @@ import (
 )
 
 // BlockStore wraps a KVStore to provide atomic block storage.
+// It provides the thin wrapper that manages the atomic state
+// transitions for the application of a Unit of Work.
 type BlockStore struct {
 	path string
 	kv   kvstore.KVStore
@@ -32,13 +34,13 @@ func NewBlockStore(path string) (*BlockStore, error) {
 }
 
 // Set adds a block into the blockstore.
-func (bs *BlockStore) Set([]byte, []byte) error {
-	return fmt.Errorf("not impl")
+func (bs *BlockStore) Set(k []byte, v []byte) error {
+	return bs.kv.Set(k, v)
 }
 
 // Get returns a block at the provided height from the blockstore.
-func (bs *BlockStore) Get([]byte) ([]byte, error) {
-	return nil, fmt.Errorf("not impl")
+func (bs *BlockStore) Get(key []byte) ([]byte, error) {
+	return bs.kv.Get(key)
 }
 
 // ClearAll removes all blocks from the block store.

--- a/persistence/blockstore/block_store.go
+++ b/persistence/blockstore/block_store.go
@@ -1,0 +1,52 @@
+package blockstore
+
+import (
+	"fmt"
+
+	"github.com/pokt-network/pocket/persistence/kvstore"
+)
+
+// BlockStore wraps a KVStore to provide atomic block storage.
+type BlockStore struct {
+	path string
+	kv   kvstore.KVStore
+}
+
+// NewBlockStore initializes a new blockstore with the given path.
+// * If "" is provided as the path, an in-memory store is used.
+func NewBlockStore(path string) (*BlockStore, error) {
+	if path == "" {
+		return &BlockStore{
+			path: "",
+			kv:   kvstore.NewMemKVStore(),
+		}, nil
+	}
+	kv, err := kvstore.NewKVStore(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init blockstore kv: %w", err)
+	}
+	return &BlockStore{
+		path: path,
+		kv:   kv,
+	}, nil
+}
+
+// Set adds a block into the blockstore.
+func (bs *BlockStore) Set([]byte, []byte) error {
+	return fmt.Errorf("not impl")
+}
+
+// Get returns a block at the provided height from the blockstore.
+func (bs *BlockStore) Get([]byte) ([]byte, error) {
+	return nil, fmt.Errorf("not impl")
+}
+
+// ClearAll removes all blocks from the block store.
+func (bs *BlockStore) ClearAll() error {
+	return bs.kv.ClearAll()
+}
+
+// Stop gracefully shuts down the blockstore.
+func (bs *BlockStore) Stop() error {
+	return bs.kv.Stop()
+}

--- a/persistence/blockstore/block_store.go
+++ b/persistence/blockstore/block_store.go
@@ -8,19 +8,25 @@ import (
 	"github.com/pokt-network/pocket/persistence/kvstore"
 )
 
+type BlockStore interface {
+	kvstore.KVStore
+}
+
+var _ BlockStore = &blockStore{}
+
 // BlockStore wraps a KVStore to provide atomic block storage.
 // It provides the thin wrapper that manages the atomic state
 // transitions for the application of a Unit of Work.
-type BlockStore struct {
+type blockStore struct {
 	path string
 	kv   kvstore.KVStore
 }
 
 // NewBlockStore initializes a new blockstore with the given path.
 // * If "" is provided as the path, an in-memory store is used.
-func NewBlockStore(path string) (*BlockStore, error) {
+func NewBlockStore(path string) (*blockStore, error) {
 	if path == "" {
-		return &BlockStore{
+		return &blockStore{
 			path: "",
 			kv:   kvstore.NewMemKVStore(),
 		}, nil
@@ -29,28 +35,35 @@ func NewBlockStore(path string) (*BlockStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to init blockstore kv: %w", err)
 	}
-	return &BlockStore{
+	return &blockStore{
 		path: path,
 		kv:   kv,
 	}, nil
 }
 
 // Set adds a block into the blockstore.
-func (bs *BlockStore) Set(k []byte, v []byte) error {
+func (bs *blockStore) Set(k []byte, v []byte) error {
 	return bs.kv.Set(k, v)
 }
 
 // Get returns a block at the provided height from the blockstore.
-func (bs *BlockStore) Get(key []byte) ([]byte, error) {
+func (bs *blockStore) Get(key []byte) ([]byte, error) {
 	return bs.kv.Get(key)
 }
 
 // ClearAll removes all blocks from the block store.
-func (bs *BlockStore) ClearAll() error {
+func (bs *blockStore) ClearAll() error {
 	return bs.kv.ClearAll()
 }
 
 // Stop gracefully shuts down the blockstore.
-func (bs *BlockStore) Stop() error {
+func (bs *blockStore) Stop() error {
 	return bs.kv.Stop()
+}
+
+// TODO
+func (bs *blockStore) Delete(key []byte) error         { return nil }
+func (bs *blockStore) Exists(key []byte) (bool, error) { return false, nil }
+func (bs *blockStore) GetAll(prefixKey []byte, descending bool) (keys, values [][]byte, err error) {
+	return nil, nil, nil
 }

--- a/persistence/blockstore/block_store.go
+++ b/persistence/blockstore/block_store.go
@@ -8,15 +8,20 @@ import (
 	"github.com/pokt-network/pocket/persistence/kvstore"
 )
 
+// BlockStore is a key-value store that maps block heights to serialized
+// block structures.
+// * It manages the atomic state transitions for applying a Unit of Work.
 type BlockStore interface {
 	kvstore.KVStore
 }
 
+// Enforce blockStore to fulfill BlockStore
 var _ BlockStore = &blockStore{}
 
-// BlockStore wraps a KVStore to manage savepoint and rollback behavior.
-// * It provides the thin wrapper that manages the atomic state transitions
-// for the application of a Unit of Work.
+// blockStore wraps a KVStore to provide atomic commits
+// and implements `BlockStore`
+// * It's responsible for the lifecycle of savepoints and
+// rollbacks with its underlying KVStore.
 type blockStore struct {
 	kv kvstore.KVStore
 }

--- a/persistence/context.go
+++ b/persistence/context.go
@@ -29,7 +29,7 @@ type PostgresContext struct {
 	stateHash string
 	// TECHDEBT(#361): These three values are pointers to objects maintained by the PersistenceModule.
 	//                 Need to simply access them via the bus.
-	blockStore *blockstore.BlockStore
+	blockStore blockstore.BlockStore
 	txIndexer  indexer.TxIndexer
 	stateTrees *stateTrees
 

--- a/persistence/context.go
+++ b/persistence/context.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pokt-network/pocket/persistence/blockstore"
 	"github.com/pokt-network/pocket/persistence/indexer"
-	"github.com/pokt-network/pocket/persistence/kvstore"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
 	"github.com/pokt-network/pocket/shared/modules"
 )

--- a/persistence/context.go
+++ b/persistence/context.go
@@ -29,7 +29,7 @@ type PostgresContext struct {
 	stateHash string
 	// TECHDEBT(#361): These three values are pointers to objects maintained by the PersistenceModule.
 	//                 Need to simply access them via the bus.
-	blockStore kvstore.KVStore
+	blockStore *blockstore.BlockStore
 	txIndexer  indexer.TxIndexer
 	stateTrees *stateTrees
 

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.53] - 2023-05-011
+
+- Refactors BlockStore into an independent component
+- Creates the BlockStore interface and package
+
 ## [0.0.0.52] - 2023-05-04
 
 - Add protocol actor specifc getter functions

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.53] - 2023-05-011
+## [0.0.0.53] - 2023-05-12
 
 - Refactors BlockStore into an independent component
 - Creates the BlockStore interface and package

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.53] - 2023-05-12
+## [0.0.0.53] - 2023-05-16
 
 - Refactors BlockStore into an independent component
 - Creates the BlockStore interface and package

--- a/persistence/kvstore/kvstore.go
+++ b/persistence/kvstore/kvstore.go
@@ -1,6 +1,6 @@
 package kvstore
 
-//go:generate mockgen -source=$GOFILE -destination=../types/mocks/block_store_mock.go github.com/pokt-network/pocket/persistence/types KVStore
+//go:generate mockgen -source=$GOFILE -destination=../types/mocks/kv_store_mock.go github.com/pokt-network/pocket/persistence/types KVStore
 
 import (
 	"errors"

--- a/persistence/module.go
+++ b/persistence/module.go
@@ -34,7 +34,7 @@ type persistenceModule struct {
 	networkId    string
 
 	// A key-value store mapping heights to blocks. Needed for block synchronization.
-	blockStore *blockstore.BlockStore
+	blockStore blockstore.BlockStore
 
 	// A tx indexer (i.e. key-value store) mapping transaction hashes to transactions. Needed for
 	// avoiding tx replays attacks, and is also used as the backing database for the transaction
@@ -226,7 +226,7 @@ func (m *persistenceModule) ReleaseWriteContext() error {
 	return nil
 }
 
-func (m *persistenceModule) GetBlockStore() *blockstore.BlockStore {
+func (m *persistenceModule) GetBlockStore() blockstore.BlockStore {
 	return m.blockStore
 }
 

--- a/shared/modules/doc/CHANGELOG.md
+++ b/shared/modules/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.12] - 2023-05-11
+## [0.0.0.12] - 2023-05-12
 
 - Updates the PersistenceModule interface to return a BlockStore instead of KVStore directly
 

--- a/shared/modules/doc/CHANGELOG.md
+++ b/shared/modules/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.12] - 2023-05-11
+
+- Updates the PersistenceModule interface to return a BlockStore instead of KVStore directly
+
 ## [0.0.0.11] - 2023-04-12
 
 - `Consensus` - Updated debug interface functions: added `PushStateSyncMetadataResponse()`, removed `SetAggregatedStateSyncMetadata()` and `GetAggregatedStateSyncMetadataMaxHeight()`

--- a/shared/modules/doc/CHANGELOG.md
+++ b/shared/modules/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.12] - 2023-05-12
+## [0.0.0.12] - 2023-05-16
 
 - Updates the PersistenceModule interface to return a BlockStore instead of KVStore directly
 

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -3,8 +3,8 @@ package modules
 //go:generate mockgen -destination=./mocks/persistence_module_mock.go github.com/pokt-network/pocket/shared/modules PersistenceModule,PersistenceRWContext,PersistenceReadContext,PersistenceWriteContext
 
 import (
+	"github.com/pokt-network/pocket/persistence/blockstore"
 	"github.com/pokt-network/pocket/persistence/indexer"
-	"github.com/pokt-network/pocket/persistence/kvstore"
 	"github.com/pokt-network/pocket/runtime/genesis"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
 	"github.com/pokt-network/pocket/shared/messaging"
@@ -22,7 +22,7 @@ type PersistenceModule interface {
 	ReleaseWriteContext() error // The module can maintain many read contexts, but only one write context can exist at a time
 
 	// BlockStore operations
-	GetBlockStore() kvstore.KVStore
+	GetBlockStore() *blockstore.BlockStore
 	NewWriteContext() PersistenceRWContext
 
 	// Indexer operations

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -22,7 +22,7 @@ type PersistenceModule interface {
 	ReleaseWriteContext() error // The module can maintain many read contexts, but only one write context can exist at a time
 
 	// BlockStore operations
-	GetBlockStore() *blockstore.BlockStore
+	GetBlockStore() blockstore.BlockStore
 	NewWriteContext() PersistenceRWContext
 
 	// Indexer operations


### PR DESCRIPTION
## Description

Refactors BlockStore out into its own component on PersistenceContext and introduces the BlockStore interface.

## Issue

Relates to #692 

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Refactors `blockStore` into its own package in `persistence/blockstore` instead of directly attaching a `KVStore` to the `PersistenceContext`.
- Creates the `BlockStore` interface
- Updates tests that previously used the KVStore mocks to use BlockStore mocks

## Testing

- [x] `make develop_test`; if any code changes were made
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made


## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [x] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
