### PR TITLE
Refactoring the assignment order of the RunCommand function in validatorPod

### DIFF
--- a/e2e/tests/validator.go
+++ b/e2e/tests/validator.go
@@ -57,8 +57,8 @@ func (v *validatorPod) RunCommand(args ...string) (*commandResult, error) {
 	cmd := exec.Command("kubectl", args...)
 	r := &commandResult{}
 	out, err := cmd.Output()
-	v.result = r
 	r.Stdout = string(out)
+	v.result = r
 	if err != nil {
 		return r, err
 	}


### PR DESCRIPTION
In the validatorPod struct's RunCommand method, there has been a minor, yet significant change in the order of operations to ensure that the result field of the validatorPod struct correctly captures the full command result.

In the previous version of the method, the command result struct r was assigned to v.result before r.Stdout was populated with the command output. This meant that v.result always contained an empty string for its Stdout field, regardless of the command's actual output.

This has now been corrected by moving the assignment of r to v.result below the line where r.Stdout is populated. This ensures that the Stdout field of v.result correctly contains the command's output, and not an empty string.

This change is important because it provides accurate command output information when referencing v.result, allowing for better debugging and error handling in the usage of validatorPod instances. While it might seem like a small change, it can significantly improve the transparency and traceability of command execution within the application.

<!-- REMOVE this comment block after following the instructions
 1. Make the title of the PR is descriptive and follows this format: `[<Module>] <DESCRIPTION>`
 2. Update the _Assigness_, _Labels_, _Projects_, _Milestone_ before submitting the PR for review.
 3. Add label(s) for the purpose (e.g. `persistence`) and, if applicable, priority (e.g. `low`) labels as well.
-->

## Description

<!-- REMOVE this comment block after following the instructions
1. Add a summary of the change including: motivation, reasons, context, dependencies, etc...
2. If applicable, specify the key files that should be looked at.
-->

## Issue

Fixes #<issue_number>

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

<!-- REMOVE this comment block after following the instructions
 List out all the changes made
-->

- Change #1
- Change #2
- ...

## Testing

- [ ] `make develop_test`; if any code changes were made
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
