### PR TITLE
Refactoring Request Body Initialization in HTTP Handlers

### DIFF
--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -83,8 +83,8 @@ func (s *rpcServer) PostV1ClientGetSession(ctx echo.Context) error {
 // TECHDEBT: This will need to be changed when the HandleRelay function is actually implemented
 // because it copies data structures from v0. For example, AATs are no longer necessary in v1.
 func (s *rpcServer) PostV1ClientRelay(ctx echo.Context) error {
-	var body RelayRequest
-	if err := ctx.Bind(&body); err != nil {
+	body := new(SessionRequest)
+	if err := ctx.Bind(body); err != nil {
 		return ctx.String(http.StatusBadRequest, "bad request")
 	}
 


### PR DESCRIPTION
Previously, the request bodies body were declared as value types, and then their addresses were passed to the ctx.Bind(&body) function.

In this commit, I have streamlined this process by declaring body as a pointer upfront. The ctx.Bind() function call now directly uses body without requiring the & operator.