### PR TITLE
Improved Error Handling in TransactionExists Function

### DIFF
--- a/persistence/block.go
+++ b/persistence/block.go
@@ -18,14 +18,17 @@ func (p *persistenceModule) TransactionExists(transactionHash string) (bool, err
 		return false, err
 	}
 	res, err := p.txIndexer.GetByHash(hash)
-	if res == nil {
-		// check for not found
-		if err != nil && err.Error() == kvstore.BadgerKeyNotFoundError {
-			return false, nil
+	if res != nil {
+		if err != nil {
+			return false, err
 		}
-		return false, err
+		return true, nil
 	}
-	return true, err
+	// check for not found
+	if err != nil && err.Error() == kvstore.BadgerKeyNotFoundError {
+		return false, nil
+	}
+	return false, err
 }
 
 func (p *PostgresContext) GetMinimumBlockHeight() (latestHeight uint64, err error) {


### PR DESCRIPTION
### Description:

This commit introduces an important update to the `TransactionExists` function in the persistence module, aiming to provide a more accurate return value and better error handling.

### Changes:

Previously, the function had an issue where it would return `true` for the boolean result even if an error occurred during the transaction search process. This was due to the function checking if the result (`res`) was `nil` before checking if an error (`err`) had occurred.

The updated version of the function first checks if the result (`res`) is not `nil` (indicating that a transaction was found), and then checks if an error occurred during the process. If an error occurred, it now correctly returns `false` for the boolean value (indicating that the transaction was not found due to the error).

### Impact:

This change is crucial as it prevents potential confusion or misleading outcomes from the `TransactionExists` function. By ensuring that the boolean result correctly reflects whether the transaction was found or not, we can provide more accurate information to the function's callers and handle potential errors more effectively.