### PR TITLE
[Persistence] Removing code duplication, improving error handling in shouldHydrateGenesisDb function and refactoring Create function

### DIFF
--- a/persistence/module.go
+++ b/persistence/module.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	_ modules.PersistenceModule = &persistenceModule{}
-	_ modules.PersistenceModule = &persistenceModule{}
 
 	_ modules.PersistenceRWContext = &PostgresContext{}
 )
@@ -120,16 +119,18 @@ func (*persistenceModule) Create(bus modules.Bus, options ...modules.ModuleOptio
 	// 		     this forces the genesis state to be reloaded on every node startup until state
 	//           sync is implemented.
 	// Determine if we should hydrate the genesis db or use the current state of the DB attached
-	if shouldHydrateGenesis, err := m.shouldHydrateGenesisDb(); err != nil {
+	shouldHydrateGenesis, err := m.shouldHydrateGenesisDb()
+	if err != nil {
 		return nil, err
-	} else if shouldHydrateGenesis {
+	}
+	if shouldHydrateGenesis {
 		m.populateGenesisState(genesisState) // fatal if there's an error
 	} else {
 		// This configurations will connect to the SQL database and key-value stores specified
 		// in the configurations and connected to those.
 		logger.Global.Info().Msg("Loading state from disk...")
 	}
-
+	
 	return m, nil
 }
 
@@ -262,7 +263,7 @@ func (m *persistenceModule) shouldHydrateGenesisDb() (bool, error) {
 
 	blockHeight, err := readCtx.GetMaximumBlockHeight()
 	if err != nil {
-		return true, nil
+		return false, err
 	}
 
 	if blockHeight > 0 {


### PR DESCRIPTION
This is the last PR I'll be submitting not to spam GitHub area with non consistent PRs. If you still find them helpful, feel free to let me know.


### Change 1:

The existing code has two identical lines that serve the same purpose, which is to check at compile-time that `persistenceModule` implements the modules.`PersistenceModule` interface. Including this line twice doesn't provide any additional benefit.


### Change 2:

In the current code, if there is an error when calling `readCtx.GetMaximumBlockHeight()`, the function simply returns `true` for `shouldHydrateGenesisDb` and ignores the error. This might lead to incorrect program behavior because the error could indicate a problem that needs to be resolved. In the revised code, the function returns the error itself, allowing the caller to handle it appropriately.

New codes comes with improved error handling in `shouldHydrateGenesisDb` function. If there's an error when calling r`eadCtx.GetMaximumBlockHeight()`, the function now correctly returns the error to the caller. This change enhances the robustness of the code by ensuring that potential errors are not silently ignored and can be properly dealt with by the calling function.


### Change 3:

In the current code, there is an unnecessary `else` statement after the `if` block that checks `shouldHydrateGenesis`. As the `if` block returns if there's an error, the following code can be moved outside of the `else` block. Removing the `else` statement makes the code simpler, easier to read, and more "Go idiomatic", as Go encourages avoiding unnecessary `else` after `return` in `if`.