### PR TITLE
[Persistence] Refactors BlockStore Interface

### DIFF
--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.52] - 2023-05-23
+## [0.0.0.52] - 2023-05-24
 
 - Updates consensus tests to use GetBlock mock instead of Get mock
 

--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.52] - 2023-05-22
+## [0.0.0.52] - 2023-05-23
 
 - Updates consensus tests to use GetBlock mock instead of Get mock
 

--- a/consensus/doc/CHANGELOG.md
+++ b/consensus/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.52] - 2023-05-22
+
+- Updates consensus tests to use GetBlock mock instead of Get mock
+
 ## [0.0.0.51] - 2023-05-16
 
 - Updates consensus test to use BlockStore mock instead of KVStore mock

--- a/consensus/e2e_tests/utils_test.go
+++ b/consensus/e2e_tests/utils_test.go
@@ -383,6 +383,7 @@ func basePersistenceMock(t *testing.T, _ modules.EventsChannel, bus modules.Bus)
 		AnyTimes()
 
 	blockStoreMock.
+		// NB: The business logic in this mock and below is vital for testing state-sync end-to-end
 		EXPECT().
 		GetBlock(gomock.Any()).
 		DoAndReturn(func(height uint64) (*coreTypes.Block, error) {

--- a/consensus/e2e_tests/utils_test.go
+++ b/consensus/e2e_tests/utils_test.go
@@ -633,7 +633,6 @@ func WaitForNextBlock(
 	advanceTime(t, clck, 10*time.Millisecond)
 
 	blockStore := pocketNodes[1].GetBus().GetPersistenceModule().GetBlockStore()
-
 	block, err := blockStore.GetBlock(height)
 	require.NoError(t, err)
 

--- a/consensus/e2e_tests/utils_test.go
+++ b/consensus/e2e_tests/utils_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pokt-network/pocket/shared/messaging"
 	"github.com/pokt-network/pocket/shared/modules"
 	mockModules "github.com/pokt-network/pocket/shared/modules/mocks"
-	"github.com/pokt-network/pocket/shared/utils"
 	"github.com/pokt-network/pocket/state_machine"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -375,37 +374,73 @@ func basePersistenceMock(t *testing.T, _ modules.EventsChannel, bus modules.Bus)
 
 	blockStoreMock := persistenceMocks.NewMockBlockStore(ctrl)
 
-	blockStoreMock.EXPECT().Get(gomock.Any()).DoAndReturn(func(height []byte) ([]byte, error) {
-		heightInt := utils.HeightFromBytes(height)
-		if bus.GetConsensusModule().CurrentHeight() < heightInt {
-			return nil, fmt.Errorf("requested height is higher than current height of the node's consensus module")
-		}
-		blockWithHeight := &coreTypes.Block{
-			BlockHeader: &coreTypes.BlockHeader{
-				Height: utils.HeightFromBytes(height),
-			},
-		}
-		return codec.GetCodec().Marshal(blockWithHeight)
-	}).AnyTimes()
+	blockStoreMock.
+		EXPECT().
+		StoreBlock(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(height []byte, block *coreTypes.Block) error {
+			return nil
+		}).
+		AnyTimes()
 
-	persistenceMock.EXPECT().GetBlockStore().Return(blockStoreMock).AnyTimes()
+	blockStoreMock.
+		EXPECT().
+		GetBlock(gomock.Any()).
+		DoAndReturn(func(height uint64) (*coreTypes.Block, error) {
+			if bus.GetConsensusModule().CurrentHeight() < height {
+				return nil, fmt.Errorf("requested height is higher than current height of the node's consensus module")
+			}
+			blockWithHeight := &coreTypes.Block{
+				BlockHeader: &coreTypes.BlockHeader{
+					Height: height,
+				},
+			}
+			return blockWithHeight, nil
+		}).
+		AnyTimes()
 
-	persistenceReadContextMock.EXPECT().GetMaximumBlockHeight().DoAndReturn(func() (uint64, error) {
-		height := bus.GetConsensusModule().CurrentHeight()
-		return height, nil
-	}).AnyTimes()
+	persistenceMock.
+		EXPECT().
+		GetBlockStore().
+		Return(blockStoreMock).
+		AnyTimes()
 
-	persistenceReadContextMock.EXPECT().GetMinimumBlockHeight().DoAndReturn(func() (uint64, error) {
-		// mock minimum block height in persistence module to 1 if current height is equal or more than 1, else return 0 as the minimum height
-		if bus.GetConsensusModule().CurrentHeight() >= 1 {
-			return 1, nil
-		}
-		return 0, nil
-	}).AnyTimes()
+	persistenceReadContextMock.
+		EXPECT().
+		GetMaximumBlockHeight().
+		DoAndReturn(func() (uint64, error) {
+			height := bus.GetConsensusModule().CurrentHeight()
+			return height, nil
+		}).
+		AnyTimes()
 
-	persistenceReadContextMock.EXPECT().GetAllValidators(gomock.Any()).Return(bus.GetRuntimeMgr().GetGenesis().Validators, nil).AnyTimes()
-	persistenceReadContextMock.EXPECT().GetBlockHash(gomock.Any()).Return("", nil).AnyTimes()
-	persistenceReadContextMock.EXPECT().Release().AnyTimes()
+	persistenceReadContextMock.
+		EXPECT().
+		GetMinimumBlockHeight().
+		DoAndReturn(func() (uint64, error) {
+			// mock minimum block height in persistence module to 1 if current height is equal or more than 1, else return 0 as the minimum height
+			if bus.GetConsensusModule().CurrentHeight() >= 1 {
+				return 1, nil
+			}
+			return 0, nil
+		}).
+		AnyTimes()
+
+	persistenceReadContextMock.
+		EXPECT().
+		GetAllValidators(gomock.Any()).
+		Return(bus.GetRuntimeMgr().GetGenesis().Validators, nil).
+		AnyTimes()
+
+	persistenceReadContextMock.
+		EXPECT().
+		GetBlockHash(gomock.Any()).
+		Return("", nil).
+		AnyTimes()
+
+	persistenceReadContextMock.
+		EXPECT().
+		Release().
+		AnyTimes()
 
 	return persistenceMock
 }
@@ -598,16 +633,11 @@ func WaitForNextBlock(
 	advanceTime(t, clck, 10*time.Millisecond)
 
 	blockStore := pocketNodes[1].GetBus().GetPersistenceModule().GetBlockStore()
-	heightBytes := utils.HeightToBytes(height)
 
-	blockBytes, err := blockStore.Get(heightBytes)
+	block, err := blockStore.GetBlock(height)
 	require.NoError(t, err)
 
-	var block coreTypes.Block
-	err = codec.GetCodec().Unmarshal(blockBytes, &block)
-	require.NoError(t, err)
-
-	return &block
+	return block
 }
 
 func waitForProposalMsgs(

--- a/consensus/state_sync/server.go
+++ b/consensus/state_sync/server.go
@@ -72,7 +72,7 @@ func (m *stateSync) HandleGetBlockRequest(blockReq *typesCons.GetBlockRequest) e
 	blockStore := m.GetBus().GetPersistenceModule().GetBlockStore()
 	block, err := blockStore.GetBlock(blockReq.Height)
 	if err != nil {
-		m.logger.Error().Err(typesCons.ErrConsensusMempoolFull).Msg(typesCons.DisregardHotstuffMessage)
+		m.logger.Error().Err(err).Msgf("failed to get block at height %d", blockReq.Height)
 		return err
 	}
 

--- a/persistence/block.go
+++ b/persistence/block.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/pokt-network/pocket/persistence/kvstore"
 	"github.com/pokt-network/pocket/persistence/types"
-	"github.com/pokt-network/pocket/shared/codec"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
-	"github.com/pokt-network/pocket/shared/utils"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -117,14 +115,4 @@ func (p *PostgresContext) insertBlock(block *coreTypes.Block) error {
 
 	_, err := tx.Exec(ctx, types.InsertBlockQuery(blockHeader.Height, blockHeader.StateHash, blockHeader.ProposerAddress, blockHeader.QuorumCertificate))
 	return err
-}
-
-// Stores the block in the key-value store
-func (p *PostgresContext) storeBlock(block *coreTypes.Block) error {
-	blockBz, err := codec.GetCodec().Marshal(block)
-	if err != nil {
-		return err
-	}
-	p.logger.Info().Uint64("height", block.BlockHeader.Height).Msg("Storing block in block store")
-	return p.blockStore.Set(utils.HeightToBytes(uint64(p.Height)), blockBz)
 }

--- a/persistence/blockstore/block_store.go
+++ b/persistence/blockstore/block_store.go
@@ -49,7 +49,7 @@ func NewBlockStore(path string) (BlockStore, error) {
 	}, nil
 }
 
-// StoreBlock takes a coreType Block and stores it.
+// StoreBlock accepts a coreType Block and stores it for the given height.
 func (bs *blockStore) StoreBlock(height uint64, block *coreTypes.Block) error {
 	b, err := codec.GetCodec().Marshal(block)
 	if err != nil {
@@ -62,13 +62,12 @@ func (bs *blockStore) StoreBlock(height uint64, block *coreTypes.Block) error {
 
 // GetBlock returns a coreTypes Block at the given height.
 func (bs *blockStore) GetBlock(height uint64) (*coreTypes.Block, error) {
-	var block coreTypes.Block
 	blockBytes, err := bs.kv.Get(utils.HeightToBytes(height))
 	if err != nil {
 		return nil, err
 	}
-	err = codec.GetCodec().Unmarshal(blockBytes, &block)
-	if err != nil {
+	var block coreTypes.Block
+	if err := codec.GetCodec().Unmarshal(blockBytes, &block); err != nil {
 		return nil, err
 	}
 	return &block, nil

--- a/persistence/blockstore/block_store.go
+++ b/persistence/blockstore/block_store.go
@@ -15,7 +15,7 @@ import (
 // block structures.
 // * It manages the atomic state transitions for applying a Unit of Work.
 type BlockStore interface {
-	kvstore.KVStore // TODO_IN_THIS_COMMIT remove this eventually and expose only the two below
+	kvstore.KVStore
 
 	GetBlock(height uint64) (*coreTypes.Block, error)
 	StoreBlock(height uint64, block *coreTypes.Block) error

--- a/persistence/context.go
+++ b/persistence/context.go
@@ -68,8 +68,8 @@ func (p *PostgresContext) Commit(proposerAddr, quorumCert []byte) error {
 		return err
 	}
 
-	// Store block in the KV store
-	if err := p.storeBlock(block); err != nil {
+	// Save the block in the BlockStore at the current height
+	if err := p.blockStore.StoreBlock(uint64(p.Height), block); err != nil {
 		return err
 	}
 

--- a/persistence/debug.go
+++ b/persistence/debug.go
@@ -5,10 +5,7 @@ import (
 	"runtime/debug"
 
 	"github.com/pokt-network/pocket/persistence/types"
-	"github.com/pokt-network/pocket/shared/codec"
-	coreTypes "github.com/pokt-network/pocket/shared/core/types"
 	"github.com/pokt-network/pocket/shared/messaging"
-	"github.com/pokt-network/pocket/shared/utils"
 	"github.com/pokt-network/smt"
 )
 
@@ -45,15 +42,9 @@ func (m *persistenceModule) HandleDebugMessage(debugMessage *messaging.DebugMess
 func (m *persistenceModule) showLatestBlockInStore(_ *messaging.DebugMessage) {
 	// TODO: Add an iterator to the `kvstore` and use that instead
 	height := m.GetBus().GetConsensusModule().CurrentHeight() - 1
-	blockBytes, err := m.GetBlockStore().Get(utils.HeightToBytes(height))
+	block, err := m.GetBlockStore().GetBlock(height)
 	if err != nil {
 		m.logger.Error().Err(err).Uint64("height", height).Msg("Error getting block from block store")
-		return
-	}
-
-	block := &coreTypes.Block{}
-	if err := codec.GetCodec().Unmarshal(blockBytes, block); err != nil {
-		m.logger.Error().Err(err).Uint64("height", height).Msg("Error decoding block from block store")
 		return
 	}
 

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.54] - 2023-05-22
+
+- Adds the BlockStore interface
+- Updates the PersistenceContext struct to use it instead of directly exposing the blockStore struct
+
 ## [0.0.0.53] - 2023-05-16
 
 - Refactors BlockStore into an independent component

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.54] - 2023-05-22
+## [0.0.0.54] - 2023-05-23
 
 - Adds the BlockStore interface
-- Updates the PersistenceContext struct to use it instead of directly exposing the blockStore struct
+- Updates the PersistenceContext struct to use BlockStore interface
 
 ## [0.0.0.53] - 2023-05-16
 

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.54] - 2023-05-23
+## [0.0.0.54] - 2023-05-24
 
 - Adds the BlockStore interface
 - Updates the PersistenceContext struct to use BlockStore interface

--- a/persistence/test/state_test.go
+++ b/persistence/test/state_test.go
@@ -7,9 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/pokt-network/pocket/shared/codec"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
-	"github.com/pokt-network/pocket/shared/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +51,6 @@ func TestStateHash_DeterministicStateWhenUpdatingAppStake(t *testing.T) {
 	for i := 0; i < len(stateHashes); i++ {
 		// Get the context at the new height and retrieve one of the apps
 		height := int64(i + 1)
-		heightBz := utils.HeightToBytes(uint64(height))
 		expectedStateHash := stateHashes[i]
 
 		db := NewTestPostgresContext(t, height)
@@ -99,13 +96,10 @@ func TestStateHash_DeterministicStateWhenUpdatingAppStake(t *testing.T) {
 		require.NoError(t, err)
 
 		// Retrieve the block
-		blockBz, err := testPersistenceMod.GetBlockStore().Get(heightBz)
+		block, err := testPersistenceMod.GetBlockStore().GetBlock(uint64(height))
 		require.NoError(t, err)
 
 		// Verify the block contents
-		var block coreTypes.Block
-		err = codec.GetCodec().Unmarshal(blockBz, &block)
-		require.NoError(t, err)
 		require.Equal(t, expectedStateHash, block.BlockHeader.StateHash) // verify block hash
 		if i > 0 {
 			require.Equal(t, stateHashes[i-1], block.BlockHeader.PrevStateHash) // verify chain chain

--- a/rpc/doc/CHANGELOG.md
+++ b/rpc/doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.19] - 2023-05-23
+
+- Updates rpc tests to use updated BlockStore mocks
+
 ## [0.0.0.18] - 2023-05-04
 
 - Add parity with V0's RPC spec

--- a/rpc/doc/CHANGELOG.md
+++ b/rpc/doc/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.0.19] - 2023-05-23
 
-- Updates rpc tests to use updated BlockStore mocks
+- Updates rpc handlers to use updated BlockStore interface
 
 ## [0.0.0.18] - 2023-05-04
 

--- a/rpc/doc/CHANGELOG.md
+++ b/rpc/doc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.19] - 2023-05-23
+## [0.0.0.19] - 2023-05-24
 
 - Updates rpc handlers to use updated BlockStore interface
 

--- a/rpc/handlers_query.go
+++ b/rpc/handlers_query.go
@@ -9,9 +9,7 @@ import (
 	"strconv"
 
 	"github.com/labstack/echo/v4"
-	"github.com/pokt-network/pocket/shared/codec"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
-	"github.com/pokt-network/pocket/shared/utils"
 )
 
 // This file contains the handlers for the v1/query path in the RPC specification
@@ -252,13 +250,8 @@ func (s *rpcServer) PostV1QueryBlock(ctx echo.Context) error {
 
 	height := uint64(s.getQueryHeight(body.Height))
 	blockStore := s.GetBus().GetPersistenceModule().GetBlockStore()
-	blockBz, err := blockStore.Get(utils.HeightToBytes(height))
+	block, err := blockStore.GetBlock(height)
 	if err != nil {
-		return ctx.String(http.StatusInternalServerError, err.Error())
-	}
-
-	block := new(coreTypes.Block)
-	if err := codec.GetCodec().Unmarshal(blockBz, block); err != nil {
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 	rpcBlock, err := s.blockToRPCBlock(block)
@@ -278,15 +271,11 @@ func (s *rpcServer) PostV1QueryBlockTxs(ctx echo.Context) error {
 
 	height := uint64(s.getQueryHeight(body.Height))
 	blockStore := s.GetBus().GetPersistenceModule().GetBlockStore()
-	blockBz, err := blockStore.Get(utils.HeightToBytes(height))
+	block, err := blockStore.GetBlock(height)
 	if err != nil {
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
 
-	block := new(coreTypes.Block)
-	if err := codec.GetCodec().Unmarshal(blockBz, block); err != nil {
-		return ctx.String(http.StatusInternalServerError, err.Error())
-	}
 	rpcBlock, err := s.blockToRPCBlock(block)
 	if err != nil {
 		return ctx.String(http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
## Description

This PR refactors the persistence module to create the BlockStore interface. In doing so, it stops higher level components from directly calling the KVStore and exposes a specialized GetBlock and StoreBlock function instead. These two will eventually be wrapped with savepoints and rollbacks logic to facilitate atomic commits to the block store.

## Issue

Parts of #562

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Creates the BlockStore interface and replaces mocks to use it where possible
- Forces height and block serialization handling down into the BlockStore module, making it cleaner and easier to get any block from the bus.

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
