### PR TITLE
[BUG] Int casting issue when sending tx

### DIFF
--- a/p2p/CHANGELOG.md
+++ b/p2p/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.51] - 2023-05-23
+
+- Use the shared codec module when marshaling the data sent over the wire
+- Introduce a hacky workaround to cast a `uint32` to a `string` since it is being passed in as a `json.Number` through some codeflow
+
 ## [0.0.0.50] - 2023-05-08
 
 - Removed unused `Transport` interface

--- a/p2p/module.go
+++ b/p2p/module.go
@@ -197,11 +197,6 @@ func (m *p2pModule) Broadcast(msg *anypb.Any) error {
 	c := &messaging.PocketEnvelope{
 		Content: msg,
 	}
-
-	m.logger.Info().
-		Interface("PocketEnvelope", c).
-		Msg("broadcasting message to network")
-
 	data, err := codec.GetCodec().Marshal(c)
 	if err != nil {
 		return err
@@ -214,11 +209,6 @@ func (m *p2pModule) Send(addr cryptoPocket.Address, msg *anypb.Any) error {
 	c := &messaging.PocketEnvelope{
 		Content: msg,
 	}
-
-	m.logger.Info().
-		Str("address", addr.ToString()).
-		Interface("PocketEnvelope", c).
-		Msg("sending message to address")
 
 	data, err := codec.GetCodec().Marshal(c)
 	if err != nil {

--- a/p2p/module.go
+++ b/p2p/module.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pokt-network/pocket/p2p/utils"
 	"github.com/pokt-network/pocket/runtime/configs"
 	"github.com/pokt-network/pocket/runtime/configs/types"
+	"github.com/pokt-network/pocket/shared/codec"
 	cryptoPocket "github.com/pokt-network/pocket/shared/crypto"
 	"github.com/pokt-network/pocket/shared/messaging"
 	"github.com/pokt-network/pocket/shared/modules"
@@ -196,12 +197,15 @@ func (m *p2pModule) Broadcast(msg *anypb.Any) error {
 	c := &messaging.PocketEnvelope{
 		Content: msg,
 	}
-	//TECHDEBT: use shared/codec for marshalling
-	data, err := proto.MarshalOptions{Deterministic: true}.Marshal(c)
+
+	m.logger.Info().
+		Interface("PocketEnvelope", c).
+		Msg("broadcasting message to network")
+
+	data, err := codec.GetCodec().Marshal(c)
 	if err != nil {
 		return err
 	}
-	m.logger.Info().Msg("broadcasting message to network")
 
 	return m.router.Broadcast(data)
 }
@@ -210,8 +214,13 @@ func (m *p2pModule) Send(addr cryptoPocket.Address, msg *anypb.Any) error {
 	c := &messaging.PocketEnvelope{
 		Content: msg,
 	}
-	//TECHDEBT: use shared/codec for marshalling
-	data, err := proto.MarshalOptions{Deterministic: true}.Marshal(c)
+
+	m.logger.Info().
+		Str("address", addr.ToString()).
+		Interface("PocketEnvelope", c).
+		Msg("sending message to address")
+
+	data, err := codec.GetCodec().Marshal(c)
 	if err != nil {
 		return err
 	}

--- a/p2p/module_raintree_test.go
+++ b/p2p/module_raintree_test.go
@@ -291,7 +291,6 @@ func testRainTreeCalls(t *testing.T, origNode string, networkSimulationConfig Te
 	p := &anypb.Any{}
 	p2pMod := p2pModules[origNode]
 	require.NoError(t, p2pMod.Broadcast(p))
-
 }
 
 func extractNumericId(valId string) int64 {

--- a/p2p/raintree/peerstore_utils.go
+++ b/p2p/raintree/peerstore_utils.go
@@ -2,6 +2,7 @@ package raintree
 
 import (
 	"math"
+	"strconv"
 )
 
 // Refer to the P2P specification for a formal description and proof of how the constants are selected
@@ -41,7 +42,7 @@ func (rtr *rainTreeRouter) getTargetsAtLevel(level uint32) []target {
 			"firstTarget":  firstTarget.serviceURL,
 			"secondTarget": secondTarget.serviceURL,
 			"height":       height,
-			"level":        level,
+			"level":        strconv.Itoa(int(level)), // TECHDEBT(#): Figure out why we need a conversion here
 			"pstoreSize":   pstoreSizeAtHeight,
 		},
 	).Msg("Targets at height")

--- a/p2p/raintree/peerstore_utils.go
+++ b/p2p/raintree/peerstore_utils.go
@@ -42,7 +42,7 @@ func (rtr *rainTreeRouter) getTargetsAtLevel(level uint32) []target {
 			"firstTarget":  firstTarget.serviceURL,
 			"secondTarget": secondTarget.serviceURL,
 			"height":       height,
-			"level":        strconv.Itoa(int(level)), // TECHDEBT(#): Figure out why we need a conversion here
+			"level":        strconv.Itoa(int(level)), // HACK(#783): Figure out why we need a conversion here
 			"pstoreSize":   pstoreSizeAtHeight,
 		},
 	).Msg("Targets at height")


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 May 23 21:42 UTC
This pull request includes a cleanup and bug fix in module.go that utilizes the shared codec module when marshaling data sent over the wire, and it introduces a hacky workaround to cast a `uint32` to a `string` since it is being passed in as a `json.Number` through some codeflow. Additionally, the changelog has been updated to reflect these changes.
<!-- reviewpad:summarize:end -->


## Origin Document

The error encountered is:

```bash
node1.consensus  | 9:11PM level=INFO broadcasting message to network PocketEnvelope={"content":{"type_url":"type.googleapis.com/utility.TxGossipMessage","value":"CtsBCl0KJ3R5cGUuZ29vZ2xlYXBpcy5jb20vdXRpbGl0eS5NZXNzYWdlU2VuZBIyChSZcEXn+ZM7GobRUrdy0giO+GK4dxIUmYBAWIreXuPWzSzOdGeuEMvjmJgaBDEwMDASFDExOTk1NjAzMDY1Mzk4NTAxNTM1GmQKIHuXVS389g22ddtxtHRZjRmsJu41Qe9N1GcGWwPkDEN8EkBMzGmDb7CQn1nbCnl6w9B1/mbzM8PVPnjRDGJMZFxoc8rx+h6O8U1PBE6bdT5srrWBXkhp78g0wjmnMZRGH8MA"}} module=p2p
node1.consensus  | echo: http: panic serving 172.20.0.1:49906: interface conversion: interface {} is json.Number, not string
node1.consensus  | goroutine 484 [running]:
node1.consensus  | net/http.(*conn).serve.func1()
node1.consensus  | 	/usr/local/go/src/net/http/server.go:1850 +0xb8
node1.consensus  | panic({0xe17d80, 0x4005759dd0})
node1.consensus  | 	/usr/local/go/src/runtime/panic.go:890 +0x260
node1.consensus  | net/http.(*timeoutHandler).ServeHTTP(0x4005736fc0, {0x1463e40, 0x40036cd4a0}, 0x4002f05900)
node1.consensus  | 	/usr/local/go/src/net/http/server.go:3412 +0x6f8
node1.consensus  | github.com/labstack/echo/v4/middleware.TimeoutConfig.ToMiddleware.func1.1({0x1480bf8, 0x4003062aa0})
node1.consensus  | 	/go/src/github.com/pocket-network/vendor/github.com/labstack/echo/v4/middleware/timeout.go:125 +0x218
node1.consensus  | github.com/labstack/echo/v4/middleware.RequestLoggerConfig.ToMiddleware.func1.1({0x1480bf8, 0x4003062aa0})
node1.consensus  | 	/go/src/github.com/pocket-network/vendor/github.com/labstack/echo/v4/middleware/request_logger.go:219 +0xe8
node1.consensus  | github.com/labstack/echo/v4.(*Echo).ServeHTTP(0x4000128240, {0x1464d10?, 0x40000e2620}, 0x4002f05900)
node1.consensus  | 	/go/src/github.com/pocket-network/vendor/github.com/labstack/echo/v4/echo.go:646 +0x430
node1.consensus  | net/http.serverHandler.ServeHTTP({0x1460cf8?}, {0x1464d10, 0x40000e2620}, 0x4002f05900)
node1.consensus  | 	/usr/local/go/src/net/http/server.go:2947 +0x2cc
node1.consensus  | net/http.(*conn).serve(0x40058f80a0, {0x1466138, 0x4002f2d9b0})
node1.consensus  | 	/usr/local/go/src/net/http/server.go:1991 +0x544
node1.consensus  | created by net/http.(*Server).Serve
node1.consensus  | 	/usr/local/go/src/net/http/server.go:3102 +0x43c
```

The following video captures 

https://github.com/pokt-network/pocket/assets/1892194/0b90a0f5-74ba-4f59-8042-4a9b9341c56e

The correct fix is to identify where/how a `json.Number` is propagated to this field, but as a temporary hacky workaround, it was cast to a string. See [this StackOverflow answer](https://stackoverflow.com/a/48444748/768439) for more details:

![Screenshot 2023-05-23 at 2 36 45 PM](https://github.com/pokt-network/pocket/assets/1892194/b78a04a6-8d46-4adc-acb5-272ed0d382f9)

## Issue

NA

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Use the shared codec module resolving a couple techdebt items
- Introduce a hacky workaround
- ...

## Testing

- [x] `make develop_test`; if any code changes were made
- [ ] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
