### PR TITLE
add POCKET_RPC_URL envar

### DIFF
--- a/app/client/cli/cmd.go
+++ b/app/client/cli/cmd.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 
+	"github.com/pokt-network/pocket/runtime"
 	"github.com/pokt-network/pocket/runtime/configs"
 	"github.com/pokt-network/pocket/runtime/defaults"
 	"github.com/spf13/cobra"
@@ -23,7 +24,7 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&remoteCLIURL, "remote_cli_url", defaults.DefaultRemoteCLIURL, "takes a remote endpoint in the form of <protocol>://<host> (uses RPC Port)")
+	rootCmd.PersistentFlags().StringVar(&remoteCLIURL, "remote_cli_url", runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL), "takes a remote endpoint in the form of <protocol>://<host> (uses RPC Port)")
 	rootCmd.PersistentFlags().BoolVar(&nonInteractive, "non_interactive", false, "if true skips the interactive prompts wherever possible (useful for scripting & automation)")
 
 	// TECHDEBT: Why do we have a data dir when we have a config path if the data dir is only storing keys?

--- a/app/client/cli/cmd.go
+++ b/app/client/cli/cmd.go
@@ -24,7 +24,7 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&remoteCLIURL, "remote_cli_url", runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL), "takes a remote endpoint in the form of <protocol>://<host> (uses RPC Port)")
+	rootCmd.PersistentFlags().StringVar(&remoteCLIURL, "remote_cli_url", runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL), "takes a remote endpoint in the form of <protocol>://<host> (uses RPC Port). Can be set via POCKET_RPC_URL environment variable.")
 	rootCmd.PersistentFlags().BoolVar(&nonInteractive, "non_interactive", false, "if true skips the interactive prompts wherever possible (useful for scripting & automation)")
 
 	// TECHDEBT: Why do we have a data dir when we have a config path if the data dir is only storing keys?

--- a/app/client/cli/debug.go
+++ b/app/client/cli/debug.go
@@ -47,7 +47,7 @@ var (
 	}
 
 	genesisPath string = runtime.GetEnv("GENESIS_PATH", "build/config/genesis.json")
-	rpcHost     string
+	rpcURL      string
 )
 
 // NOTE: this is required by the linter, otherwise a simple string constant would have been enough
@@ -60,13 +60,7 @@ func init() {
 	dbg.AddCommand(NewDebugSubCommands()...)
 	rootCmd.AddCommand(dbg)
 
-	// by default, we point at the same endpoint used by the CLI but the debug client is used either in docker-compose of K8S, therefore we cater for overriding
-	validator1Endpoint := defaults.Validator1EndpointDockerCompose
-	if runtime.IsProcessRunningInsideKubernetes() {
-		validator1Endpoint = defaults.Validator1EndpointK8S
-	}
-
-	rpcHost = runtime.GetEnv("RPC_HOST", validator1Endpoint)
+	rpcURL = runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL)
 }
 
 // NewDebugSubCommands builds out the list of debug subcommands by matching the
@@ -107,7 +101,6 @@ func NewDebugCommand() *cobra.Command {
 func persistentPreRun(cmd *cobra.Command, _ []string) {
 	// TECHDEBT: this is to keep backwards compatibility with localnet
 	configPath = runtime.GetEnv("CONFIG_PATH", "build/config/config.validator1.json")
-	rpcURL := fmt.Sprintf("http://%s:%s", rpcHost, defaults.DefaultRPCPort)
 
 	runtimeMgr := runtime.NewManagerFromFiles(
 		configPath, genesisPath,

--- a/app/docs/CHANGELOG.md
+++ b/app/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.9] - 2023-06-08
+
+- Adds `POCKET_RPC_URL` environment variable to the client CLI
+
 ## [0.0.0.8] - 2023-06-06
 
 - Adds `query nodeRoles` sub-command the client CLI

--- a/build/deployments/docker-compose.yaml
+++ b/build/deployments/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       dockerfile: ./build/Dockerfile.client
     environment:
       # Any host that is visible and connected to the cluster can be arbitrarily selected as the RPC host
-      - RPC_HOST=validator1
+      - POCKET_RPC_URL=http://validator1:50832
     volumes:
       - ${PWD}:/go/src/github.com/pocket-network
     stdin_open: true

--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.47] - 2023-06-08
+
+- Adds `POCKET_RPC_URL` environment variable, which replaces an existing `RPC_HOST`
+
 ## [0.0.0.46] - 2023-06-06
 
 - Renames config files and actor hostnames

--- a/build/localnet/cluster-manager/main.go
+++ b/build/localnet/cluster-manager/main.go
@@ -34,7 +34,7 @@ var (
 )
 
 func init() {
-	rpcURL = fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", defaults.Validator1EndpointK8S), defaults.DefaultRPCPort)
+	rpcURL = runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL)
 }
 
 func main() {

--- a/build/localnet/manifests/cli-client.yaml
+++ b/build/localnet/manifests/cli-client.yaml
@@ -74,8 +74,8 @@ spec:
             - name: POCKET_PERSISTENCE_NODE_SCHEMA
               value: validator1
               # Any host that is visible and connected to the cluster can be arbitrarily selected as the RPC host
-            - name: RPC_HOST
-              value: full-node-001-pocket
+            - name: POCKET_RPC_URL
+              value: http://pocket-validators:50832
               # TECHDEBT(#678): debug client requires hostname to participate
               # in P2P networking.
             - name: POCKET_P2P_HOSTNAME

--- a/build/localnet/manifests/cluster-manager.yaml
+++ b/build/localnet/manifests/cluster-manager.yaml
@@ -19,8 +19,8 @@ spec:
       args:
         - cluster-manager
       env:
-        - name: RPC_HOST
-          value: pocket-full-nodes
+        - name: POCKET_RPC_URL
+          value: http://pocket-validators:50832
   serviceAccountName: cluster-manager
 ---
 apiVersion: v1

--- a/e2e/docs/CHANGELOG.md
+++ b/e2e/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.9] - 2023-06-08
+
+- Adds `POCKET_RPC_URL` environment variable, which replaces an existing `RPC_HOST`
+
 ## [0.0.0.8] - 2023-05-31
 
 - Adds the query feature file

--- a/e2e/tests/validator.go
+++ b/e2e/tests/validator.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	"fmt"
 	"os/exec"
 
 	"github.com/pokt-network/pocket/runtime"
@@ -18,7 +17,7 @@ var (
 )
 
 func init() {
-	rpcURL = fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", "pocket-validators"), defaults.DefaultRPCPort)
+	rpcURL = runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL)
 }
 
 // cliPath is the path of the binary installed and is set by the Tiltfile

--- a/e2e/tests/validator.go
+++ b/e2e/tests/validator.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"fmt"
 	"os/exec"
 
 	"github.com/pokt-network/pocket/runtime"
@@ -17,7 +18,8 @@ var (
 )
 
 func init() {
-	rpcURL = runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL)
+	pocketValidatorsRpcFallback := fmt.Sprintf("http://%s:%s", runtime.GetEnv("RPC_HOST", "pocket-validators"), defaults.DefaultRPCPort)
+	rpcURL = runtime.GetEnv("POCKET_RPC_URL", pocketValidatorsRpcFallback)
 }
 
 // cliPath is the path of the binary installed and is set by the Tiltfile

--- a/p2p/CHANGELOG.md
+++ b/p2p/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.54] - 2023-06-08
+
+- Adds `POCKET_RPC_URL` environment variable, which replaces an existing `RPC_HOST`
+
 ## [0.0.0.53] - 2023-06-01
 
 - Moved nonce field from RainTreeMessage to PocketEnvelope protobuf types

--- a/p2p/providers/current_height_provider/rpc/provider.go
+++ b/p2p/providers/current_height_provider/rpc/provider.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -16,12 +15,12 @@ import (
 )
 
 var (
-	_       current_height_provider.CurrentHeightProvider = &rpcCurrentHeightProvider{}
-	rpcHost string
+	_      current_height_provider.CurrentHeightProvider = &rpcCurrentHeightProvider{}
+	rpcURL string
 )
 
 func init() {
-	rpcHost = runtime.GetEnv("RPC_HOST", defaults.DefaultRPCHost)
+	rpcURL = runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL)
 }
 
 type rpcCurrentHeightProvider struct {
@@ -65,7 +64,7 @@ func (rchp *rpcCurrentHeightProvider) CurrentHeight() uint64 {
 
 func NewRPCCurrentHeightProvider(options ...modules.ModuleOption) *rpcCurrentHeightProvider {
 	rchp := &rpcCurrentHeightProvider{
-		rpcURL: fmt.Sprintf("http://%s:%s", rpcHost, defaults.DefaultRPCPort), // TODO: Make port configurable
+		rpcURL: rpcURL,
 	}
 
 	for _, o := range options {

--- a/p2p/providers/peerstore_provider/rpc/provider.go
+++ b/p2p/providers/peerstore_provider/rpc/provider.go
@@ -19,13 +19,13 @@ import (
 )
 
 var (
-	_       peerstore_provider.PeerstoreProvider = &rpcPeerstoreProvider{}
-	rpcHost string
+	_      peerstore_provider.PeerstoreProvider = &rpcPeerstoreProvider{}
+	rpcURL string
 )
 
 func init() {
 	// by default, we point at the same endpoint used by the CLI but the debug client is used either in docker-compose of K8S, therefore we cater for overriding
-	rpcHost = runtime.GetEnv("RPC_HOST", defaults.DefaultRPCHost)
+	rpcURL = runtime.GetEnv("POCKET_RPC_URL", defaults.DefaultRemoteCLIURL)
 }
 
 type rpcPeerstoreProvider struct {
@@ -39,7 +39,7 @@ type rpcPeerstoreProvider struct {
 
 func NewRPCPeerstoreProvider(options ...modules.ModuleOption) *rpcPeerstoreProvider {
 	rabp := &rpcPeerstoreProvider{
-		rpcURL: fmt.Sprintf("http://%s:%s", rpcHost, defaults.DefaultRPCPort), // TODO: Make port configurable
+		rpcURL: rpcURL,
 	}
 
 	for _, o := range options {


### PR DESCRIPTION
## Description

This PR adds a `POCKET_RPC_URL` environment variable. We are going to use it as a fallback in the CLI if the `remote_cli_url` flag is not specified. Similarly, that environment variable also has a fallback default value, which is `http://localhost:50832` — the same default value we've always used.

In addition, I've replaced an existing variable, `RPC_HOST`, which was previously used in the cluster manager and e2e tests, with this new variable to maintain consistency.

Once this is merged, I'll update the DevNet infrastructure, so it will also use the new configuration.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jun 23 23:29 UTC
This pull request adds support for a POCKET_RPC_URL environment variable, replacing the older RPC_HOST variable used in several places across the codebase. It also updates two URLs in the docker-compose and CLI client manifests. Finally, it removes two unused variables and a redundant import.
<!-- reviewpad:summarize:end -->

## Issue

Fixes #814

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Adds new environment variable `POCKET_RPC_URL`
- Replaces existing usage of `RPC_HOST` env variable with `POCKET_RPC_URL`

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
