### PR TITLE
[Tooling] chore: break tilt e2e test cache

### DIFF
--- a/build/docs/CHANGELOG.md
+++ b/build/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.0.48] - 2023-06-13
+
+- Added `-count=1` to tilt e2e-test execution to break the go test cache
+
 ## [0.0.0.47] - 2023-06-13
 
 - Replaced `RPC_HOST` with `POCKET_REMOTE_CLI_URL` or `--pocket-remote-cli-url` where appropriate

--- a/build/localnet/Tiltfile
+++ b/build/localnet/Tiltfile
@@ -273,7 +273,7 @@ k8s_resource(
 
 # E2E test button
 test_go('e2e-tests', '{root_dir}/e2e/tests'.format(root_dir=root_dir), '.',
-        extra_args=["-v", "-tags=e2e"],
+        extra_args=["-v", "-count=1", "-tags=e2e"],
         labels=['e2e-tests'],
         trigger_mode=TRIGGER_MODE_MANUAL,
 )


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Jun 23 14:39 UTC
This pull request contains two patches. The first patch breaks the go test cache by adding `-count=1` to tilt e2e-test execution. The second patch updates the changelog to reflect the changes made.
<!-- reviewpad:summarize:end -->

## Issue

N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Add `-count=1` flag to tilt e2e test execution to break the go test cache

## Testing

- [ ] `make develop_test`; if any code changes were made
- [ ] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made


## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
