### PR TITLE
[Persistence] Update KVStore to use Badger wrapper functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/opencontainers/runc v1.1.4 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/persistence/kvstore/kvstore.go
+++ b/persistence/kvstore/kvstore.go
@@ -59,76 +59,70 @@ func NewMemKVStore() KVStore {
 }
 
 func (store *badgerKVStore) Set(key, value []byte) error {
-	tx := store.db.NewTransaction(true)
-	defer tx.Discard()
-
-	if err := tx.Set(key, value); err != nil {
-		return err
-	}
-
-	return tx.Commit()
+	return store.db.Update(func(tx *badger.Txn) error {
+		return tx.Set(key, value)
+	})
 }
 
 func (store *badgerKVStore) Get(key []byte) ([]byte, error) {
-	tx := store.db.NewTransaction(false)
-	defer tx.Discard()
+	var val []byte
+	if err := store.db.View(func(tx *badger.Txn) error {
+		item, err := tx.Get(key)
+		if err != nil {
+			return err
+		}
 
-	item, err := tx.Get(key)
-	if err != nil {
+		val, err = item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
 		return nil, err
 	}
-
-	value, err := item.ValueCopy(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	return value, nil
+	return val, nil
 }
 
 func (store *badgerKVStore) Delete(key []byte) error {
-	tx := store.db.NewTransaction(true)
-	defer tx.Discard()
-
-	return tx.Delete(key)
+	return store.db.Update(func(tx *badger.Txn) error {
+		return tx.Delete(key)
+	})
 }
 
 func (store *badgerKVStore) GetAll(prefix []byte, descending bool) (keys, values [][]byte, err error) {
-	// INVESTIGATE: research `badger.views` for further improvements and optimizations
-	// Reference https://pkg.go.dev/github.com/dgraph-io/badger#readme-prefix-scans
-	txn := store.db.NewTransaction(false)
-	defer txn.Discard()
-
-	opt := badger.DefaultIteratorOptions
-	opt.Prefix = prefix
-	opt.Reverse = descending
-	if descending {
-		prefix = prefixEndBytes(prefix)
-	}
-	it := txn.NewIterator(opt)
-	defer it.Close()
-
-	keys = make([][]byte, 0)
-	values = make([][]byte, 0)
-
-	for it.Seek(prefix); it.Valid(); it.Next() {
-		item := it.Item()
-		err = item.Value(func(v []byte) error {
-			b := make([]byte, len(v))
-			copy(b, v)
-			keys = append(keys, item.Key())
-			values = append(values, b)
-			return nil
-		})
-		if err != nil {
-			return
+	if err := store.db.View(func(tx *badger.Txn) error {
+		opt := badger.DefaultIteratorOptions
+		opt.Prefix = prefix
+		opt.Reverse = descending
+		if descending {
+			prefix = prefixEndBytes(prefix)
 		}
+		it := tx.NewIterator(opt)
+		defer it.Close()
+
+		keys = make([][]byte, 0)
+		values = make([][]byte, 0)
+
+		for it.Seek(prefix); it.Valid(); it.Next() {
+			item := it.Item()
+			err = item.Value(func(v []byte) error {
+				b := make([]byte, len(v))
+				copy(b, v)
+				keys = append(keys, item.Key())
+				values = append(values, b)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, nil, err
 	}
-	return
+
+	return keys, values, nil
 }
 
 func (store *badgerKVStore) Exists(key []byte) (bool, error) {

--- a/persistence/kvstore/kvstore_test.go
+++ b/persistence/kvstore/kvstore_test.go
@@ -26,8 +26,8 @@ func TestKVStore_BasicOperations(t *testing.T) {
 		{
 			name:     "Successfully sets a value in the store",
 			op:       "set",
-			key:      []byte("foo"),
-			value:    []byte("baz"),
+			key:      []byte("testKey"),
+			value:    []byte("testValue"),
 			fail:     false,
 			expected: nil,
 		},
@@ -35,7 +35,7 @@ func TestKVStore_BasicOperations(t *testing.T) {
 			name:     "Successfully updates a value in the store",
 			op:       "set",
 			key:      []byte("foo"),
-			value:    []byte("bar"),
+			value:    []byte("new value"),
 			fail:     false,
 			expected: nil,
 		},
@@ -115,6 +115,9 @@ func TestKVStore_BasicOperations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			err := store.ClearAll()
+			require.NoError(t, err)
+			setupStore(t, store)
 			switch tc.op {
 			case "set":
 				err := store.Set(tc.key, tc.value)
@@ -324,5 +327,13 @@ func TestKVStore_ClearAll(t *testing.T) {
 	require.Equal(t, 0, len(allValues))
 
 	err = store.Stop()
+	require.NoError(t, err)
+}
+
+func setupStore(t *testing.T, store KVStore) {
+	t.Helper()
+	err := store.Set([]byte("foo"), []byte("bar"))
+	require.NoError(t, err)
+	err = store.Set([]byte("baz"), []byte("bin"))
 	require.NoError(t, err)
 }

--- a/persistence/kvstore/kvstore_test.go
+++ b/persistence/kvstore/kvstore_test.go
@@ -1,0 +1,328 @@
+package kvstore
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	badger "github.com/dgraph-io/badger/v3"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKVStore_BasicOperations(t *testing.T) {
+	store := NewMemKVStore()
+	require.NotNil(t, store)
+
+	invalidKey := [65001]byte{}
+	testCases := []struct {
+		name     string
+		op       string
+		key      []byte
+		value    []byte
+		fail     bool
+		expected error
+	}{
+		{
+			name:     "Successfully sets a value in the store",
+			op:       "set",
+			key:      []byte("foo"),
+			value:    []byte("baz"),
+			fail:     false,
+			expected: nil,
+		},
+		{
+			name:     "Successfully updates a value in the store",
+			op:       "set",
+			key:      []byte("foo"),
+			value:    []byte("bar"),
+			fail:     false,
+			expected: nil,
+		},
+		{
+			name:     "Fails to set value to nil key",
+			op:       "set",
+			key:      nil,
+			value:    []byte("bar"),
+			fail:     true,
+			expected: badger.ErrEmptyKey,
+		},
+		{
+			name:     "Fails to set a value to a key that is too large",
+			op:       "set",
+			key:      invalidKey[:],
+			value:    []byte("bar"),
+			fail:     true,
+			expected: errors.Errorf("Key with size 65001 exceeded 65000 limit. Key:\n%s", hex.Dump(invalidKey[:1<<10])),
+		},
+		{
+			name:     "Successfully manages to retrieve a value from the store",
+			op:       "get",
+			key:      []byte("foo"),
+			value:    []byte("bar"),
+			fail:     false,
+			expected: nil,
+		},
+		{
+			name:     "Fails to get a value that is not stored",
+			op:       "get",
+			key:      []byte("bar"),
+			value:    nil,
+			fail:     true,
+			expected: badger.ErrKeyNotFound,
+		},
+		{
+			name:     "Fails when the key is empty",
+			op:       "get",
+			key:      nil,
+			value:    nil,
+			fail:     true,
+			expected: badger.ErrEmptyKey,
+		},
+		{
+			name:     "Successfully deletes a value in the store",
+			op:       "delete",
+			key:      []byte("foo"),
+			value:    nil,
+			fail:     false,
+			expected: nil,
+		},
+		{
+			name:     "Fails to delete a value not in the store",
+			op:       "delete",
+			key:      []byte("bar"),
+			value:    nil,
+			fail:     false,
+			expected: nil,
+		},
+		{
+			name:     "Fails to set value to nil key",
+			op:       "delete",
+			key:      nil,
+			value:    nil,
+			fail:     true,
+			expected: badger.ErrEmptyKey,
+		},
+		{
+			name:     "Fails to set a value to a key that is too large",
+			op:       "delete",
+			key:      invalidKey[:],
+			value:    nil,
+			fail:     true,
+			expected: errors.Errorf("Key with size 65001 exceeded 65000 limit. Key:\n%s", hex.Dump(invalidKey[:1<<10])),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			switch tc.op {
+			case "set":
+				err := store.Set(tc.key, tc.value)
+				if tc.fail {
+					require.Error(t, err)
+					require.EqualError(t, tc.expected, err.Error())
+				} else {
+					require.NoError(t, err)
+					got, err := store.Get(tc.key)
+					require.NoError(t, err)
+					require.Equal(t, tc.value, got)
+				}
+			case "get":
+				got, err := store.Get(tc.key)
+				if tc.fail {
+					require.Error(t, err)
+					require.EqualError(t, tc.expected, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tc.value, got)
+				}
+			case "delete":
+				err := store.Delete(tc.key)
+				if tc.fail {
+					require.Error(t, err)
+					require.EqualError(t, tc.expected, err.Error())
+				} else {
+					require.NoError(t, err)
+					_, err := store.Get(tc.key)
+					require.EqualError(t, err, badger.ErrKeyNotFound.Error())
+				}
+			}
+		})
+	}
+
+	err := store.Stop()
+	require.NoError(t, err)
+}
+
+func TestKVStore_GetAllBasic(t *testing.T) {
+	store := NewMemKVStore()
+	require.NotNil(t, store)
+
+	keys := [][]byte{
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("baz"),
+		[]byte("bin"),
+	}
+	values := [][]byte{
+		[]byte("oof"),
+		[]byte("rab"),
+		[]byte("zab"),
+		[]byte("nib"),
+	}
+
+	for i := 0; i < len(keys); i++ {
+		err := store.Set(keys[i], values[i])
+		require.NoError(t, err)
+	}
+
+	allKeys, allValues, err := store.GetAll([]byte{}, false)
+	require.NoError(t, err)
+	require.Equal(t, len(keys), len(allKeys))
+	require.Equal(t, len(values), len(allValues))
+
+	for i := 0; i < len(keys); i++ {
+		require.Contains(t, allKeys, keys[i])
+		require.Contains(t, allValues, values[i])
+	}
+
+	err = store.Stop()
+	require.NoError(t, err)
+}
+
+func TestKVStore_GetAllPrefixed(t *testing.T) {
+	store := NewMemKVStore()
+	require.NotNil(t, store)
+
+	keys := [][]byte{
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("baz"),
+		[]byte("bin"),
+		[]byte("testKey1"),
+		[]byte("testKey2"),
+		[]byte("testKey3"),
+		[]byte("testKey4"),
+	}
+	values := [][]byte{
+		[]byte("oof"),
+		[]byte("rab"),
+		[]byte("zab"),
+		[]byte("nib"),
+		[]byte("testValue1"),
+		[]byte("testValue2"),
+		[]byte("testValue3"),
+		[]byte("testValue4"),
+	}
+
+	for i := 0; i < len(keys); i++ {
+		err := store.Set(keys[i], values[i])
+		require.NoError(t, err)
+	}
+
+	allKeys, allValues, err := store.GetAll([]byte("testKey"), false)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(allKeys))
+	require.Equal(t, 4, len(allValues))
+
+	for i := 0; i < len(keys); i++ {
+		if strings.HasPrefix(string(keys[i]), "testKey") {
+			require.Contains(t, allKeys, keys[i])
+			require.Contains(t, allValues, values[i])
+		} else {
+			require.NotContains(t, allKeys, keys[i])
+			require.NotContains(t, allValues, values[i])
+		}
+	}
+
+	err = store.Stop()
+	require.NoError(t, err)
+}
+
+func TestKVStore_Exists(t *testing.T) {
+	store := NewMemKVStore()
+	require.NotNil(t, store)
+
+	keys := [][]byte{
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("baz"),
+		[]byte("bin"),
+	}
+	values := [][]byte{
+		[]byte("oof"),
+		nil,
+		[]byte("zab"),
+		[]byte("nib"),
+	}
+
+	for i := 0; i < len(keys); i++ {
+		err := store.Set(keys[i], values[i])
+		require.NoError(t, err)
+	}
+
+	// Key exists in store with a value
+	exists, err := store.Exists([]byte("foo"))
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	// Key exists but has nil value
+	exists, err = store.Exists([]byte("bar"))
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// Key does not exist
+	exists, err = store.Exists([]byte("oof"))
+	require.EqualError(t, err, badger.ErrKeyNotFound.Error())
+	require.False(t, exists)
+
+	err = store.Stop()
+	require.NoError(t, err)
+}
+
+func TestKVStore_ClearAll(t *testing.T) {
+	store := NewMemKVStore()
+	require.NotNil(t, store)
+
+	keys := [][]byte{
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("baz"),
+		[]byte("bin"),
+		[]byte("testKey1"),
+		[]byte("testKey2"),
+		[]byte("testKey3"),
+		[]byte("testKey4"),
+	}
+	values := [][]byte{
+		[]byte("oof"),
+		[]byte("rab"),
+		[]byte("zab"),
+		[]byte("nib"),
+		[]byte("testValue1"),
+		[]byte("testValue2"),
+		[]byte("testValue3"),
+		[]byte("testValue4"),
+	}
+
+	for i := 0; i < len(keys); i++ {
+		err := store.Set(keys[i], values[i])
+		require.NoError(t, err)
+	}
+
+	allKeys, allValues, err := store.GetAll([]byte{}, false)
+	require.NoError(t, err)
+	require.Equal(t, len(keys), len(allKeys))
+	require.Equal(t, len(values), len(allValues))
+
+	err = store.ClearAll()
+	require.NoError(t, err)
+
+	allKeys, allValues, err = store.GetAll([]byte{}, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(allKeys))
+	require.Equal(t, 0, len(allValues))
+
+	err = store.Stop()
+	require.NoError(t, err)
+}

--- a/persistence/kvstore/kvstore_test.go
+++ b/persistence/kvstore/kvstore_test.go
@@ -56,7 +56,7 @@ func TestKVStore_BasicOperations(t *testing.T) {
 			expected: errors.Errorf("Key with size 65001 exceeded 65000 limit. Key:\n%s", hex.Dump(invalidKey[:1<<10])),
 		},
 		{
-			name:     "Successfully manages to retrieve a value from the store",
+			name:     "Successfully retrieve a value from the store",
 			op:       "get",
 			key:      []byte("foo"),
 			value:    []byte("bar"),


### PR DESCRIPTION
## Description

This PR introduces unit tests to cover the KVStore's functionality as well as updating the KVStore logic to use the Badger wrapper functions `update`, `view`, etc.

This fixes the issues around deleting keys from the KVStore.

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Update KVStore to use badger's wrapper functions
- Add KVStore unit tests

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
