### PR TITLE
[General] Ignore false positive secret uncovered by `ggshield` on main

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,5 +1,5 @@
 secret:
   ignored-matches:
-  - match: d1585b49ffa864bfb76b2432b26933a866c3cf621a9d5dd41690c1568edd85ed
-    name: Generic High Entropy Secret - /Users/olshansky/workspace/pocket/pocket/charts/pocket/templates/configmap-genesis.yaml
+    - match: d1585b49ffa864bfb76b2432b26933a866c3cf621a9d5dd41690c1568edd85ed
+      name: Generic High Entropy Secret - charts/pocket/templates/configmap-genesis.yaml
 version: 2

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,5 @@
+secret:
+  ignored-matches:
+  - match: d1585b49ffa864bfb76b2432b26933a866c3cf621a9d5dd41690c1568edd85ed
+    name: Generic High Entropy Secret - /Users/olshansky/workspace/pocket/pocket/charts/pocket/templates/configmap-genesis.yaml
+version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ tools/wiki
 
 # ignore highest precedence config file read by default
 /config.json
+
+# ggshield
+.cache_ggshield

--- a/Makefile
+++ b/Makefile
@@ -579,5 +579,5 @@ ggshield_secrets_scan: ## Scans the project for secrets using ggshield
 	ggshield secret scan path --recursive .
 
 .PHONY: ggshield_secrets_add
-ggshield_secrets_add: ## Ignore recently foudn secrets using ggshield
+ggshield_secrets_add: ## Ignore recently found secrets using ggshield
 	ggshield secret ignore --last-found

--- a/Makefile
+++ b/Makefile
@@ -573,3 +573,11 @@ search_interfaces: ## Greps and outputs all of the structs in the project (exclu
 .PHONY: search_protos
 search_protos: ## Finds all of the proto files in the project (excluding vendor)
 	find . -name "*.proto" -not -path "./vendor/*"
+
+.PHONY: ggshield_secrets_scan
+ggshield_secrets_scan: ## Scans the project for secrets using ggshield
+	ggshield secret scan path --recursive .
+
+.PHONY: ggshield_secrets_add
+ggshield_secrets_add: ## Ignore recently foudn secrets using ggshield
+	ggshield secret ignore --last-found

--- a/Makefile
+++ b/Makefile
@@ -579,5 +579,5 @@ ggshield_secrets_scan: ## Scans the project for secrets using ggshield
 	ggshield secret scan path --recursive .
 
 .PHONY: ggshield_secrets_add
-ggshield_secrets_add: ## Ignore recently found secrets using ggshield
+ggshield_secrets_add: ## A helper that adds the last results from `make ggshield_secrets_scan`, store in `.cache_ggshield` to `.gitguardian.yaml`. See `ggshield for more configuratiosn`
 	ggshield secret ignore --last-found


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jun 23 22:06 UTC
This pull request includes changes to add .gitguardian.yaml file to ignore secrets and gitignore patterns for ggshield. There are also updates to the Makefile to include new targets for ggshield to scan and ignore secrets, as well as an update to make the path relative in the .gitguardian.yaml file.
<!-- reviewpad:summarize:end -->

## Issue

NA

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Added `ggshiled` helpers to scan and ignore secrets in the future
- Ignoring a secret that was introduced by #827 that was blocking main seen [here](https://github.com/pokt-network/pocket/pull/803/checks?check_run_id=14359233756)
- 
![Screenshot 2023-06-20 at 2 50 59 PM](https://github.com/pokt-network/pocket/assets/1892194/0e627b42-aaf0-4f4f-89b9-a8aaf76c08e3)

## Testing

NA
