### PR TITLE
[Linters/CI] fixes current golangci-lint errors

### DIFF
--- a/app/client/cli/consensus.go
+++ b/app/client/cli/consensus.go
@@ -2,10 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 
 	"github.com/pokt-network/pocket/app/client/cli/flags"
 	"github.com/pokt-network/pocket/rpc"
+	"github.com/spf13/cobra"
 )
 
 func init() {

--- a/p2p/raintree/router.go
+++ b/p2p/raintree/router.go
@@ -55,7 +55,7 @@ type rainTreeRouter struct {
 	peersManager          *rainTreePeersManager
 	pstoreProvider        peerstore_provider.PeerstoreProvider
 	currentHeightProvider providers.CurrentHeightProvider
-	nonceDeduper          *mempool.GenericFIFOSet[uint64, uint64]
+	nonceDeduper          *mempool.GenericFIFOSet[uint64, uint64] //nolint:unused // TODO(@bryanchriswhite): do we need this?
 }
 
 func NewRainTreeRouter(bus modules.Bus, cfg *config.RainTreeConfig) (typesP2P.Router, error) {

--- a/p2p/utils_test.go
+++ b/p2p/utils_test.go
@@ -83,6 +83,7 @@ func validatorId(i int) string {
 	return fmt.Sprintf(serviceURLFormat, i)
 }
 
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func waitForNetworkSimulationCompletion(t *testing.T, wg *sync.WaitGroup) {
 	// Wait for all messages to be transmitted
 	done := make(chan struct{})
@@ -104,6 +105,8 @@ func waitForNetworkSimulationCompletion(t *testing.T, wg *sync.WaitGroup) {
 // ~~~~~~ RainTree Unit Test Mocks ~~~~~~
 
 // createP2PModules returns a map of configured p2pModules keyed by an incremental naming convention (eg: `val_1`, `val_2`, etc.)
+//
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func createP2PModules(t *testing.T, busMocks []*mockModules.MockBus, netMock mocknet.Mocknet) (p2pModules map[string]*p2pModule) {
 	peerIDs := setupMockNetPeers(t, netMock, len(busMocks))
 
@@ -117,6 +120,7 @@ func createP2PModules(t *testing.T, busMocks []*mockModules.MockBus, netMock moc
 	return
 }
 
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func setupMockNetPeers(t *testing.T, netMock mocknet.Mocknet, numPeers int) (peerIDs []libp2pPeer.ID) {
 	// Add a libp2p peers/hosts to the `MockNet` with the keypairs corresponding
 	// to the genesis validators' keypairs
@@ -146,6 +150,8 @@ func setupMockNetPeers(t *testing.T, netMock mocknet.Mocknet, numPeers int) (pee
 
 // createMockRuntimeMgrs creates `numValidators` instances of mocked `RuntimeMgr` that are essentially
 // representing the runtime environments of the validators that we will use in our tests
+//
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func createMockRuntimeMgrs(t *testing.T, numValidators int) []modules.RuntimeMgr {
 	ctrl := gomock.NewController(t)
 	mockRuntimeMgrs := make([]modules.RuntimeMgr, numValidators)
@@ -180,6 +186,7 @@ func createMockRuntimeMgrs(t *testing.T, numValidators int) []modules.RuntimeMgr
 	return mockRuntimeMgrs
 }
 
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func createMockBuses(t *testing.T, runtimeMgrs []modules.RuntimeMgr) []*mockModules.MockBus {
 	mockBuses := make([]*mockModules.MockBus, len(runtimeMgrs))
 	for i := range mockBuses {
@@ -227,6 +234,8 @@ func createMockGenesisState(valKeys []cryptoPocket.PrivateKey) *genesis.GenesisS
 }
 
 // Bus Mock - needed to return the appropriate modules when accessed
+//
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func prepareBusMock(busMock *mockModules.MockBus,
 	persistenceMock *mockModules.MockPersistenceModule,
 	consensusMock *mockModules.MockConsensusModule,
@@ -238,6 +247,8 @@ func prepareBusMock(busMock *mockModules.MockBus,
 }
 
 // Consensus mock - only needed for validatorMap access
+//
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func prepareConsensusMock(t *testing.T, busMock *mockModules.MockBus) *mockModules.MockConsensusModule {
 	ctrl := gomock.NewController(t)
 	consensusMock := mockModules.NewMockConsensusModule(ctrl)
@@ -279,6 +290,8 @@ func preparePersistenceMock(t *testing.T, busMock *mockModules.MockBus, genesisS
 }
 
 // Telemetry mock - Needed to help with proper counts for number of expected network writes
+//
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func prepareTelemetryMock(t *testing.T, busMock *mockModules.MockBus, valId string, wg *sync.WaitGroup, expectedNumNetworkWrites int) *mockModules.MockTelemetryModule {
 	ctrl := gomock.NewController(t)
 	telemetryMock := mockModules.NewMockTelemetryModule(ctrl)
@@ -309,6 +322,8 @@ func prepareNoopTimeSeriesAgentMock(t *testing.T) *mockModules.MockTimeSeriesAge
 }
 
 // Events metric mock - Needed to help with proper counts for number of expected network writes
+//
+//nolint:unused // TODO(@bryanchriswhite): do we need this?
 func prepareEventMetricsAgentMock(t *testing.T, valId string, wg *sync.WaitGroup, expectedNumNetworkWrites int) *mockModules.MockEventMetricsAgent {
 	ctrl := gomock.NewController(t)
 	eventMetricsAgentMock := mockModules.NewMockEventMetricsAgent(ctrl)


### PR DESCRIPTION
## Description

Resolves current errors on `main` related to `golangci-lint` linters checks not passing.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jun 23 22:00 UTC
This pull request fixes current golangci-lint errors. It touches three files, making a total of 17 insertions and 2 deletions. The changes include the removal of a duplicated import statement, the commenting of an unused code element, and the modification of a variable's data type in one function within a Go package. There are also some unused code elements and mocks included in the patch.
<!-- reviewpad:summarize:end -->

## Type of change

Please mark the relevant option(s):


- [x] Code health or cleanup

## List of changes

Resolves the following issues reported by `golangci-lint`:

```
app/client/cli/consensus.go:4: File is not `goimports`-ed (goimports)
	"fmt"
p2p/raintree/router.go:58:2: field `nonceDeduper` is unused (unused)
	nonceDeduper          *mempool.GenericFIFOSet[uint64, uint64]
	^
p2p/utils_test.go:86:6: func `waitForNetworkSimulationCompletion` is unused (unused)
func waitForNetworkSimulationCompletion(t *testing.T, wg *sync.WaitGroup) {
     ^
p2p/utils_test.go:107:6: func `createP2PModules` is unused (unused)
func createP2PModules(t *testing.T, busMocks []*mockModules.MockBus, netMock mocknet.Mocknet) (p2pModules map[string]*p2pModule) {
     ^
p2p/utils_test.go:120:6: func `setupMockNetPeers` is unused (unused)
func setupMockNetPeers(t *testing.T, netMock mocknet.Mocknet, numPeers int) (peerIDs []libp2pPeer.ID) {
     ^
p2p/utils_test.go:149:6: func `createMockRuntimeMgrs` is unused (unused)
func createMockRuntimeMgrs(t *testing.T, numValidators int) []modules.RuntimeMgr {
     ^
p2p/utils_test.go:183:6: func `createMockBuses` is unused (unused)
func createMockBuses(t *testing.T, runtimeMgrs []modules.RuntimeMgr) []*mockModules.MockBus {
     ^
p2p/utils_test.go:230:6: func `prepareBusMock` is unused (unused)
func prepareBusMock(busMock *mockModules.MockBus,
     ^
p2p/utils_test.go:241:6: func `prepareConsensusMock` is unused (unused)
func prepareConsensusMock(t *testing.T, busMock *mockModules.MockBus) *mockModules.MockConsensusModule {
     ^
p2p/utils_test.go:282:6: func `prepareTelemetryMock` is unused (unused)
func prepareTelemetryMock(t *testing.T, busMock *mockModules.MockBus, valId string, wg *sync.WaitGroup, expectedNumNetworkWrites int) *mockModules.MockTelemetryModule {
     ^
p2p/utils_test.go:312:6: func `prepareEventMetricsAgentMock` is unused (unused)
func prepareEventMetricsAgentMock(t *testing.T, valId string, wg *sync.WaitGroup, expectedNumNetworkWrites int) *mockModules.MockEventMetricsAgent {
     ^
```
