### PR TITLE
[Persistence] Adds TreeStore Module

### DIFF
--- a/persistence/context.go
+++ b/persistence/context.go
@@ -31,7 +31,7 @@ type PostgresContext struct {
 	//                 Need to simply access them via the bus.
 	blockStore blockstore.BlockStore
 	txIndexer  indexer.TxIndexer
-	stateTrees modules.TreeStore
+	stateTrees modules.TreeStoreModule
 
 	networkId string
 }
@@ -50,7 +50,7 @@ func (p *PostgresContext) RollbackToSavePoint(bytes []byte) error {
 // IMPROVE(#361): Guarantee the integrity of the state
 // Full details in the thread from the PR review: https://github.com/pokt-network/pocket/pull/285#discussion_r1018471719
 func (p *PostgresContext) ComputeStateHash() (string, error) {
-	stateHash, err := p.stateTrees.Update(p.tx, p.txIndexer, uint64(p.Height))
+	stateHash, err := p.stateTrees.Update(p.tx, uint64(p.Height))
 	if err != nil {
 		return "", err
 	}

--- a/persistence/docs/CHANGELOG.md
+++ b/persistence/docs/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.0.58] - 2023-06-14
+## [0.0.0.59] - 2023-06-14
+
+- Refactors the persistence treeStore to be an IntegratableModule
+
+## [0.0.0.58] - 2023-06-13
 
 - Refactors the stateTrees implementation off of the PersistenceContext and into its in module
 - Implements the new Update and Commit pattern with the SMT trees in the trees module

--- a/persistence/module.go
+++ b/persistence/module.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	_ modules.PersistenceModule = &persistenceModule{}
-	_ modules.PersistenceModule = &persistenceModule{}
 
 	_ modules.PersistenceRWContext = &PostgresContext{}
 )
@@ -44,7 +43,7 @@ type persistenceModule struct {
 
 	// stateTrees manages all of the merkle trees maintained by the
 	// persistence module that roll up into the state commitment.
-	stateTrees modules.TreeStore
+	stateTrees modules.TreeStoreModule
 
 	// Only one write context is allowed at a time
 	writeContext *PostgresContext
@@ -104,8 +103,7 @@ func (*persistenceModule) Create(bus modules.Bus, options ...modules.ModuleOptio
 		return nil, err
 	}
 
-	// TECHDEBT (#808): Make TreeStore into a full Module
-	stateTrees, err := trees.NewStateTrees(persistenceCfg.TreesStoreDir)
+	treeModule, err := trees.Create(bus, trees.WithTreeStoreDirectory(persistenceCfg.TreesStoreDir))
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +114,7 @@ func (*persistenceModule) Create(bus modules.Bus, options ...modules.ModuleOptio
 
 	m.blockStore = blockStore
 	m.txIndexer = txIndexer
-	m.stateTrees = stateTrees
+	m.stateTrees = treeModule
 
 	// TECHDEBT: reconsider if this is the best place to call `populateGenesisState`. Note that
 	// 		     this forces the genesis state to be reloaded on every node startup until state
@@ -235,10 +233,6 @@ func (m *persistenceModule) GetBlockStore() blockstore.BlockStore {
 
 func (m *persistenceModule) GetTxIndexer() indexer.TxIndexer {
 	return m.txIndexer
-}
-
-func (m *persistenceModule) GetTreeStore() modules.TreeStore {
-	return m.stateTrees
 }
 
 func (m *persistenceModule) GetNetworkID() string {

--- a/persistence/trees/module.go
+++ b/persistence/trees/module.go
@@ -1,0 +1,73 @@
+package trees
+
+import (
+	"fmt"
+
+	"github.com/pokt-network/pocket/persistence/kvstore"
+	"github.com/pokt-network/pocket/shared/modules"
+	"github.com/pokt-network/smt"
+)
+
+func (*treeStore) Create(bus modules.Bus, options ...modules.TreeStoreOption) (modules.TreeStoreModule, error) {
+	m := &treeStore{}
+
+	for _, option := range options {
+		option(m)
+	}
+
+	m.SetBus(bus)
+
+	if err := m.setupTrees(); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func Create(bus modules.Bus, options ...modules.TreeStoreOption) (modules.TreeStoreModule, error) {
+	return new(treeStore).Create(bus, options...)
+}
+
+// WithTreeStoreDirectory assigns the path where the tree store
+// saves its data.
+func WithTreeStoreDirectory(path string) modules.TreeStoreOption {
+	return func(m modules.TreeStoreModule) {
+		mod, ok := m.(*treeStore)
+		if ok {
+			mod.treeStoreDir = path
+		}
+	}
+}
+
+func (t *treeStore) setupTrees() error {
+	if t.treeStoreDir == ":memory:" {
+		return t.setupInMemory()
+	}
+
+	t.merkleTrees = make(map[merkleTree]*smt.SMT, int(numMerkleTrees))
+	t.nodeStores = make(map[merkleTree]kvstore.KVStore, int(numMerkleTrees))
+
+	for tree := merkleTree(0); tree < numMerkleTrees; tree++ {
+		nodeStore, err := kvstore.NewKVStore(fmt.Sprintf("%s/%s_nodes", t.treeStoreDir, merkleTreeToString[tree]))
+		if err != nil {
+			return err
+		}
+		t.nodeStores[tree] = nodeStore
+		t.merkleTrees[tree] = smt.NewSparseMerkleTree(nodeStore, smtTreeHasher)
+	}
+
+	return nil
+}
+
+func (t *treeStore) setupInMemory() error {
+	t.merkleTrees = make(map[merkleTree]*smt.SMT, int(numMerkleTrees))
+	t.nodeStores = make(map[merkleTree]kvstore.KVStore, int(numMerkleTrees))
+
+	for tree := merkleTree(0); tree < numMerkleTrees; tree++ {
+		nodeStore := kvstore.NewMemKVStore() // For testing, `smt.NewSimpleMap()` can be used as well
+		t.nodeStores[tree] = nodeStore
+		t.merkleTrees[tree] = smt.NewSparseMerkleTree(nodeStore, smtTreeHasher)
+	}
+
+	return nil
+}

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -3,7 +3,6 @@ package modules
 //go:generate mockgen -destination=./mocks/persistence_module_mock.go github.com/pokt-network/pocket/shared/modules PersistenceModule,PersistenceRWContext,PersistenceReadContext,PersistenceWriteContext
 
 import (
-	"github.com/jackc/pgx/v5"
 	"github.com/pokt-network/pocket/persistence/blockstore"
 	"github.com/pokt-network/pocket/persistence/indexer"
 	"github.com/pokt-network/pocket/runtime/genesis"
@@ -25,10 +24,6 @@ type PersistenceModule interface {
 	// BlockStore maps a block height to an *coreTypes.IndexedTransaction
 	GetBlockStore() blockstore.BlockStore
 
-	// TreeStore manages atomic access to a set of merkle trees
-	// that compose the state hash.
-	GetTreeStore() TreeStore
-
 	NewWriteContext() PersistenceRWContext
 
 	// Indexer operations
@@ -37,17 +32,6 @@ type PersistenceModule interface {
 
 	// Debugging / development only
 	HandleDebugMessage(*messaging.DebugMessage) error
-}
-
-// TreeStore defines the interface for atomic updates and rollbacks to the internal
-// merkle trees that compose the state hash of pocket.
-type TreeStore interface {
-	// Update returns the new state hash for a given height.
-	// * Update inherits the pgx transaction's read view of the database and builds the trees according to that view.
-	// TODO(#808): Change interface to `Update(pgtx pgx.Tx, height uint64) (string, error)`
-	Update(pgtx pgx.Tx, txi indexer.TxIndexer, height uint64) (string, error)
-	// DebugClearAll completely clears the state of the trees. For debugging purposes only.
-	DebugClearAll() error
 }
 
 // Interface defining the context within which the node can operate with the persistence layer.

--- a/shared/modules/treestore_module.go
+++ b/shared/modules/treestore_module.go
@@ -1,0 +1,30 @@
+package modules
+
+import (
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	TreeStoreModuleName = "tree_store"
+)
+
+type TreeStoreOption func(TreeStoreModule)
+
+type TreeStoreFactory = FactoryWithOptions[TreeStoreModule, TreeStoreOption]
+
+// TreeStoreModules defines the interface for atomic updates and rollbacks to the internal
+// merkle trees that compose the state hash of pocket.
+type TreeStoreModule interface {
+	IntegratableModule
+
+	// Update returns the new state hash for a given height.
+	// * Height is passed through to the Update function and is used to query the TxIndexer for transactions
+	// to update into the merkle tree set
+	// * Passing a higher height will cause a change but repeatedly calling the same or a lower height will
+	// not incur a change.
+	// * By nature of it taking a pgx transaction at runtime, Update inherits the pgx transaction's read view of the
+	// database.
+	Update(pgtx pgx.Tx, height uint64) (string, error)
+	// DebugClearAll completely clears the state of the trees. For debugging purposes only.
+	DebugClearAll() error
+}


### PR DESCRIPTION
## Description

Loads the TreeStore from a proper module and allows it access to the bus.

## Issue

Refactor related to #756
This PR is the sum of feedback from #808. 

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Makes the TreeStore component into a proper module.
- Removes the txIndexer from the Update method interface.

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
