### PR TITLE
[Persistence][Bug] Fix Actor Schema Assignment for ValidatorActor in GetActor

### DIFF
--- a/persistence/actor.go
+++ b/persistence/actor.go
@@ -17,7 +17,7 @@ func (p *PostgresContext) GetActor(actorType coreTypes.ActorType, address []byte
 	case types.FishermanActor.GetActorType():
 		schema = types.FishermanActor
 	case types.ValidatorActor.GetActorType():
-		schema = types.FishermanActor
+		schema = types.ValidatorActor
 	default:
 		return nil, fmt.Errorf("invalid actor type: %s", actorType)
 	}


### PR DESCRIPTION
## Issue:

An issue was discovered in the `GetActor` function defined in `actor.go`. Specifically, when the `actorType` input argument matches with `types.ValidatorActor.GetActorType()`, the `schema` variable is currently assigned as `types.FishermanActor`. This appears to be a typo or error, as logically `schema` should be assigned `types.ValidatorActor` in this case. This could potentially cause `GetActor` to behave unexpectedly when called with `types.ValidatorActor.GetActorType()` as it would process as if it were `types.FishermanActor.GetActorType()`.

## Proposed Fix:

This pull request corrects the `schema` assignment for `types.ValidatorActor.GetActorType()` from `types.FishermanActor` to `types.ValidatorActor`, thus aligning the function behavior with the expected logic.

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->