### PR TITLE
Update vault_test.go

### DIFF
--- a/app/client/keybase/hashicorp/vault_test.go
+++ b/app/client/keybase/hashicorp/vault_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 	// pulls an image, creates a container based on it and runs it
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "vault",
-		Tag:        "latest",
+		Tag:        "1.13.3",
 		Env: []string{
 			"VAULT_DEV_ROOT_TOKEN_ID=dev-only-token",
 			"VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200",


### PR DESCRIPTION
The latest tag was removed for some reason: https://github.com/docker-library/official-images/commit/32c2455241a13e31b9c46cb109294d2bc6c46ba0

Let's pin `1.13.3`.