### PR TITLE
QOL: add bash completion for p1 to localnet client

### DIFF
--- a/build/localnet/Tiltfile
+++ b/build/localnet/Tiltfile
@@ -120,7 +120,7 @@ docker_build_with_restart(
     "client-image",
     root_dir,
     dockerfile_contents="""FROM debian:bullseye
-RUN apt-get update && apt-get install -y procps bash-completion
+RUN apt-get update && apt-get install -y procps bash-completion jq
 RUN echo "source /etc/bash_completion" >> ~/.bashrc
 # tail -n +2 removes the first line of the completion script since the CLI spits out some logs
 RUN echo "source <(p1 completion bash | tail -n +2)" >> ~/.bashrc

--- a/build/localnet/Tiltfile
+++ b/build/localnet/Tiltfile
@@ -120,8 +120,11 @@ docker_build_with_restart(
     "client-image",
     root_dir,
     dockerfile_contents="""FROM debian:bullseye
-RUN apt-get update && apt-get install -y procps
-WORKDIR /
+RUN apt-get update && apt-get install -y procps bash-completion
+RUN echo "source /etc/bash_completion" >> ~/.bashrc
+# tail -n +2 removes the first line of the completion script since the CLI spits out some logs
+RUN echo "source <(p1 completion bash | tail -n +2)" >> ~/.bashrc
+WORKDIR /root
 COPY bin/p1-linux /usr/local/bin/p1
 """,
     only=["bin/p1-linux"],


### PR DESCRIPTION
if you ever wondered if we could have tab completions inside localnet fret no more! This PR adds it to the cli client pod so you don't have to.

I looked at adding it to the docker setup, but that's not using the binary.

Enjoy! 👩🏻‍💻

```
make localnet_up # of course
make localnet_shell
root@dev-cli-client-9f4579876-5pmn7:~# p1 <TAB>
# Account  (Account specific commands)
# Application  (Application actor specific commands)
# Consensus  (Consensus specific commands)
# Fisherman  (Fisherman actor specific commands)
# Governance  (Governance specific commands)
# Keys  (Key specific commands)
# Query  (Commands related to querying on-chain data via the node's RPC server)
# Servicer  (Servicer specific commands)
# System  (Commands related to health and troubleshooting of the node instance)
# Validator  (Validator actor specific commands)
# completion  (Generate the autocompletion script for the specified shell)
# debug  (Debug utility for rapid development)
# help  (Help about any command)
# {"level":"debug","time":"2023-06-30T03:13:31Z","message":"Debug keybase initializing... Restoring from the embedded backup file..."}
```

