### PR TITLE
[IBC] Add length check in RemovePrefix function

### DIFF
--- a/ibc/host/prefix.go
+++ b/ibc/host/prefix.go
@@ -17,5 +17,8 @@ func ApplyPrefix(prefix coreTypes.CommitmentPrefix, path string) coreTypes.Commi
 
 // RemovePrefix removes the prefix from the provided CommitmentPath returning a path string
 func RemovePrefix(prefix coreTypes.CommitmentPrefix, path coreTypes.CommitmentPath) string {
+    if len(path) < len(prefix)+len(delimiter) {
+        return ""
+    }
 	return string(path[len(prefix)+len(delimiter):])
 }


### PR DESCRIPTION
## Problem:
The `RemovePrefix` function in `prefix.go` currently performs a slice operation on the `path` argument without first checking if the `path` is long enough to accommodate the slice operation. If the length of `path` is less than the combined length of `prefix` and `delimiter`, this will result in a runtime panic due to out-of-range slice indices.

## Solution:
This PR adds a check to ensure the length of `path` is sufficient before the slice operation is performed. If the length of `path` is less than the combined length of `prefix` and `delimiter`, the function returns an empty string.

## Changes:
Added length check to `RemovePrefix` function in `prefix.go`.