### PR TITLE
[IBC] Add nil check on proof for membership and non-membership proof creation

### DIFF
--- a/ibc/store/proofs_ics23.go
+++ b/ibc/store/proofs_ics23.go
@@ -63,7 +63,7 @@ func VerifyNonMembership(root ics23.CommitmentRoot, proof *ics23.CommitmentProof
 // in the SMT provided
 func createMembershipProof(tree *smt.SMT, key, value []byte) (*ics23.CommitmentProof, error) {
 	proof, err := tree.Prove(key)
-	if err != nil {
+	if err != nil || proof == nil {
 		return nil, coreTypes.ErrCreatingProof(err)
 	}
 	return convertSMPToExistenceProof(proof, key, value), nil
@@ -72,10 +72,9 @@ func createMembershipProof(tree *smt.SMT, key, value []byte) (*ics23.CommitmentP
 // createNonMembershipProof generates a CommitmentProof object verifying the membership of an unrealted key at the given key in the SMT provided
 func createNonMembershipProof(tree *smt.SMT, key []byte) (*ics23.CommitmentProof, error) {
 	proof, err := tree.Prove(key)
-	if err != nil {
+	if err != nil || proof == nil {
 		return nil, coreTypes.ErrCreatingProof(err)
 	}
-
 	return convertSMPToExclusionProof(proof, key), nil
 }
 


### PR DESCRIPTION
## Problem:
In `proofs_ics23.go`, the `createMembershipProof` and `createNonMembershipProof` functions call `tree.Prove(key)` and then pass the `proof` to the `convertSMPToExistenceProof` or `convertSMPToExclusionProof` functions without checking if `proof` is `nil`. This could lead to a panic due to a nil pointer dereference if `tree.Prove(key)` returns a `nil` proof.

## Solution:
This PR adds a check to verify if `proof` is `nil` before passing it to the `convertSMPToExistenceProof` or `convertSMPToExclusionProof` functions. If `proof` is `nil`, an error is returned.

## Changes:
Added nil check on `proof` in `createMembershipProof` and `createNonMembershipProof` functions in `proofs_ics23.go`.