### PR TITLE
[IBC] Prevent Potential Overflow in Event Channel of Bus

### DIFF
--- a/runtime/bus.go
+++ b/runtime/bus.go
@@ -51,6 +51,12 @@ func (m *bus) RegisterModule(module modules.Module) {
 }
 
 func (m *bus) PublishEventToBus(e *messaging.PocketEnvelope) {
+	// Check if channel is at capacity
+	if len(m.channel) == cap(m.channel) {
+		logger.Global.Logger.Warn().
+			Msg("event channel at capacity, dropping event")
+		return
+	}
 	m.channel <- e
 }
 


### PR DESCRIPTION
## Problem:

In the current `bus.go` file, the `PublishEventToBus()` function pushes events into the channel without checking if the channel is already at capacity. If the rate of incoming events exceeds the channel's capacity to process them, it could potentially lead to deadlock or unhandled panic.

## Solution:
The solution involves adding a check in the `PublishEventToBus()` function to ensure that the event channel isn't already at capacity before attempting to publish an event. If the channel is at capacity, a warning message is logged, and the event is dropped.

This change helps ensure the stability of the application by preventing potential channel overflow issues. It effectively guards against scenarios where a rapid influx of events could cause the application to lock up or crash.