### PR TITLE
disable persistance of volumes on LocalNet

### DIFF
--- a/charts/pocket/README.md
+++ b/charts/pocket/README.md
@@ -105,7 +105,7 @@ privateKeySecretKeyRef:
 | persistence.accessModes | list | `["ReadWriteOnce"]` | persistent Volume Access Modes |
 | persistence.annotations | object | `{}` | annotations of the persistent volume claim |
 | persistence.dataSource | object | `{}` | custom data source of the persistent volume claim |
-| persistence.enabled | bool | `true` | enable persistent volume claim |
+| persistence.enabled | bool | `false` | enable persistent volume claim |
 | persistence.existingClaim | string | `""` | name of an existing PVC to use for persistence |
 | persistence.reclaimPolicy | string | `"Delete"` | persistent volume reclaim policy |
 | persistence.selector | object | `{}` | selector to match an existing Persistent Volume |

--- a/charts/pocket/values.yaml
+++ b/charts/pocket/values.yaml
@@ -42,7 +42,7 @@ externalPostgresql:
 
 persistence:
   # -- enable persistent volume claim
-  enabled: true
+  enabled: false
   # -- size of the persistent volume claim
   size: 8Gi
   # -- storage class of the persistent volume claim


### PR DESCRIPTION
## Description

Turning off volumes on LocalNet makes it easier to provision nodes, as they no longer depend on Kubernetes volumes. The LocalNet nodes are ephemeral anyway, so we don't lose anything by doing that.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Jul 23 01:18 UTC
This pull request includes two patches. 

The first patch disables persistence of volumes on LocalNet by setting the `enabled` field to `false` in the `charts/pocket/values.yaml` file.

The second patch adds generated helm docs by updating the `charts/pocket/README.md` file. The `persistence.enabled` field is also set to `false` in this patch.

Overall, these patches disable the persistent volume claim feature and add documentation changes.
<!-- reviewpad:summarize:end -->

