### PR TITLE
[P2P] Fix flaky P2P tests

### DIFF
--- a/p2p/background/router_test.go
+++ b/p2p/background/router_test.go
@@ -303,6 +303,23 @@ func TestBackgroundRouter_Broadcast(t *testing.T) {
 	// setup notifee/notify BEFORE bootstrapping
 	notifee := &libp2pNetwork.NotifyBundle{
 		ConnectedF: func(_ libp2pNetwork.Network, _ libp2pNetwork.Conn) {
+			// TECHDEBT: it's rare but possible that a host will re-connect,
+			// causing the `bootstrapWaitgroup` to go negative.
+			// This test should be redesigned using atomic counters or
+			// something similar to avoid this issue.
+			defer func() {
+				if err := recover(); err != nil {
+					if err.(error).Error() == "sync: negative WaitGroup counter" {
+						// ignore negative WaitGroup counter error
+						return
+					}
+					// fail the test for anything else; converting the panic into
+					// test failure allows the test to run with the `-count` flag
+					// to completion.
+					t.Fatal(err)
+				}
+			}()
+
 			t.Logf("connected!")
 			bootstrapWaitgroup.Done()
 		},


### PR DESCRIPTION
## Description

There were two tests which were expressing flaky behavior. In both cases the tests failed via panic, which is my hypothetical explanation for why nothing printed in the test failure output; I think that CI step is not sensitive to the panic failure mode output.

To reproduce and/or verify this change, use the `-count=X` and `-run` flags to run a specific test `X` number of times consecutively:

```bash
go test -count=10 -run Libp2pKademliaPeerDiscovery ./p2p/background

go test -count=10 -run BackgroundRouter_broadcast ./p2p/background
```

### `TestLibp2pKademliaPeerDiscovery`

Wasn't calling `#Close()` on its libp2p `Host` or it's DHT. This has been added in a `t.Cleanup(...)`.

### `BackgroundRouter_broadcast`

Was panicking when an unanticipated connection is made in the context of kademlia overlay network bootstrapping (which is effectively out of our control). The test now recovers from the panic, ignores this specific error, and fails the test otherwise (any other error).

## Issue

N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- handle flaky negative WaitGroup panic in background router broadcast test
- handle flaky kad baseline test by adding proper cleanup

## Testing

- [x] `make develop_test`; if any code changes were made
- [ ] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
