### PR TITLE
[Core] Add trigger_ci target that pushes an empty commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ kubectl_check:
 	fi; \
 	}
 
+.PHONY: trigger_ci
+trigger_ci: ## Trigger the CI pipeline by submitting an empty commit; See https://github.com/pokt-network/pocket/issues/900 for details
+	git commit --allow-empty -m "Empty commit"
+	git push
+
 .PHONY: prompt_user
 # Internal helper target - prompt the user before continuing
 prompt_user:


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Jul 23 23:22 UTC
This pull request adds a new target `trigger_ci` to the Makefile. The `trigger_ci` target triggers the CI pipeline by submitting an empty commit.
<!-- reviewpad:summarize:end -->

## Issue

#900

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [X] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Add a make target called `trigger_ci` that pushes an empty commit

## Testing

- `make trigger_ci`