### PR TITLE
[Codec] Add new Interface Registry

### DIFF
--- a/shared/codec/interface_registry.go
+++ b/shared/codec/interface_registry.go
@@ -1,0 +1,155 @@
+package codec
+
+import (
+	"errors"
+	"fmt"
+	reflect "reflect"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+var (
+	// Exported accessor
+	globalRegistry InterfaceRegistry = &registry{}
+
+	// Errors
+	ErrNotInterface               = errors.New("not an interface")
+	ErrNotPointer                 = errors.New("not a pointer")
+	ErrInterfaceAlreadyRegistered = errors.New("interface already registered")
+	ErrNotRegistered              = errors.New("interface not registered")
+	ErrCastingToProto             = errors.New("error casting to proto.Message")
+
+	ErrDoesNotImplement = func(iface, impl string) error {
+		return fmt.Errorf("%s does not implement %s", impl, iface)
+	}
+	ErrImplementationNotRegistered = func(impl, iface string) error {
+		return fmt.Errorf("%s not registered as an implementation of %s", impl, iface)
+	}
+)
+
+func init() {
+	globalRegistry = newInterfaceRegistry()
+}
+
+type InterfaceRegistry interface {
+	// RegisterInterface registers an interface with the registry.
+	RegisterInterface(any) error
+	// RegisterImplementations registers implementations of an interface with the registry.
+	RegisterImplementations(iface any, impls ...proto.Message) error
+	// MarshalInterface marshalls an interface into a byte array.
+	MarshalInterface(any) ([]byte, error)
+	// UnmarshalInterface unmarshalls a byte array into a generic interface
+	UnmarshalInterface(anyPbBz []byte, iface any) error
+}
+
+type registry struct {
+	// interfaces is a map of interfaces to their implementations.
+	interfaces map[reflect.Type]map[string]reflect.Type
+}
+
+func newInterfaceRegistry() InterfaceRegistry {
+	return &registry{
+		interfaces: make(map[reflect.Type]map[string]reflect.Type),
+	}
+}
+
+func GetInterfaceRegistry() InterfaceRegistry {
+	return globalRegistry
+}
+
+func (r *registry) RegisterInterface(iface any) error {
+	// get interface type
+	ifaceType := reflect.TypeOf(iface).Elem()
+	// check if it's an interface
+	if ifaceType.Kind() != reflect.Interface {
+		return ErrNotInterface
+	}
+	// check if its already registered
+	if _, ok := r.interfaces[ifaceType]; ok {
+		return ErrInterfaceAlreadyRegistered
+	}
+	// create a new map for implementations
+	r.interfaces[ifaceType] = make(map[string]reflect.Type)
+	return nil
+}
+
+func (r *registry) RegisterImplementations(iface any, impls ...proto.Message) error {
+	// get interface type
+	ifaceType := reflect.TypeOf(iface).Elem()
+	// get map of implementations
+	imap, ok := r.interfaces[ifaceType]
+	if !ok {
+		return ErrNotRegistered
+	}
+	// for each implementation provided register the proto name and type
+	for _, impl := range impls {
+		protoName := string(proto.MessageName(impl))
+		implType := reflect.TypeOf(impl)
+		if !implType.AssignableTo(ifaceType) {
+			return ErrDoesNotImplement(ifaceType.Name(), protoName)
+		}
+		imap[protoName] = implType
+	}
+	return nil
+}
+
+func (r *registry) MarshalInterface(iface any) ([]byte, error) {
+	// cast to a proto.Message
+	protoIface, ok := iface.(proto.Message)
+	if !ok {
+		return nil, ErrCastingToProto
+	}
+	// convert to *anypb.Any{}
+	anyIface, err := GetCodec().ToAny(protoIface)
+	if err != nil {
+		return nil, err
+	}
+	// marshal the *anypb.Any{}
+	return GetCodec().Marshal(anyIface)
+}
+
+func (r *registry) UnmarshalInterface(anyPbBz []byte, iface any) error {
+	// unmarshal into an *anypb.Any{}
+	anyPb := new(anypb.Any)
+	if err := GetCodec().Unmarshal(anyPbBz, anyPb); err != nil {
+		return err
+	}
+
+	// get the value of the interface
+	rv := reflect.ValueOf(iface)
+	// ensure it is a pointer
+	if rv.Kind() != reflect.Ptr {
+		return ErrNotPointer
+	}
+	rt := rv.Elem().Type()
+	// ensure it is an interface
+	if rt.Kind() != reflect.Interface {
+		return ErrNotInterface
+	}
+
+	// get the map of implementations
+	imap, ok := r.interfaces[rt]
+	if !ok {
+		return ErrNotRegistered
+	}
+	// remove the anypb type prefix
+	typeUrl := strings.TrimPrefix(anyPb.TypeUrl, "type.googleapis.com/")
+	// get the implementation type
+	implType, ok := imap[typeUrl]
+	if !ok {
+		return ErrImplementationNotRegistered(typeUrl, rt.Name())
+	}
+
+	// create a new instance of the implementation
+	n := reflect.New(implType.Elem()).Interface().(proto.Message)
+	// unmarshall the anypb value into the implementation
+	if err := GetCodec().Unmarshal(anyPb.Value, n); err != nil {
+		return err
+	}
+
+	// set the interface value to the implementation
+	rv.Elem().Set(reflect.ValueOf(n))
+	return nil
+}

--- a/shared/codec/interface_registry_test.go
+++ b/shared/codec/interface_registry_test.go
@@ -1,0 +1,166 @@
+package codec
+
+import (
+	"fmt"
+	reflect "reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+type TestProtoInterface interface {
+	proto.Message
+	Stringify() string
+}
+
+func (t *TestProtoStructure) Stringify() string {
+	return fmt.Sprintf("%d-%s-%v", t.Field1, t.Field2, t.Field3)
+}
+
+var _ TestProtoInterface = &TestProtoStructure{}
+
+func TestInterfaceRegistry_RegisterInterface(t *testing.T) {
+	registry := newInterfaceRegistry()
+
+	// registers an interface
+	err := registry.RegisterInterface((*TestProtoInterface)(nil))
+	require.NoError(t, err)
+
+	// fails to register the same interface
+	err = registry.RegisterInterface((*TestProtoInterface)(nil))
+	require.ErrorIs(t, err, ErrInterfaceAlreadyRegistered)
+
+	// fails to register a non-interface
+	tp := &TestProtoStructure{}
+	err = registry.RegisterInterface(tp)
+	require.ErrorIs(t, err, ErrNotInterface)
+}
+
+func TestInterfaceRegistry_RegisterImplementations(t *testing.T) {
+	registry := newInterfaceRegistry()
+
+	tp := &TestProtoStructure{
+		Field1: 1,
+		Field2: "test",
+		Field3: true,
+	}
+
+	// fails to registers an implementation when interface isnt registered
+	err := registry.RegisterImplementations(
+		(*TestProtoInterface)(nil),
+		tp,
+	)
+	require.ErrorIs(t, err, ErrNotRegistered)
+
+	// registers an interface
+	err = registry.RegisterInterface((*TestProtoInterface)(nil))
+	require.NoError(t, err)
+
+	// registers an implementation
+	err = registry.RegisterImplementations(
+		(*TestProtoInterface)(nil),
+		tp,
+	)
+	require.NoError(t, err)
+
+	// fails to register a message that doesn't implement the interface
+	tp2 := &TestProtoStructure2{
+		Field1: 1,
+		Field2: "test",
+	}
+	err = registry.RegisterImplementations(
+		(*TestProtoInterface)(nil),
+		tp2,
+	)
+	require.Equal(t, err, ErrDoesNotImplement(
+		reflect.TypeOf((*TestProtoInterface)(nil)).Elem().Name(),
+		string(proto.MessageName(tp2)),
+	))
+}
+
+func TestInterfaceRegistry_MarshalInterface(t *testing.T) {
+	registry := newInterfaceRegistry()
+
+	tp := &TestProtoStructure{
+		Field1: 1,
+		Field2: "test",
+		Field3: true,
+	}
+	var pi TestProtoInterface = tp
+
+	tp2 := &struct {
+		Field1 int
+		Field2 string
+		Field3 bool
+	}{
+		Field1: 1,
+		Field2: "test",
+		Field3: true,
+	}
+
+	// fails to marhsal when interface isnt a proto.Message
+	_, err := registry.MarshalInterface(tp2)
+	require.ErrorIs(t, err, ErrCastingToProto)
+
+	// marshals the interface
+	bz, err := registry.MarshalInterface(pi)
+	require.NoError(t, err)
+
+	anyPb, err := GetCodec().ToAny(tp)
+	require.NoError(t, err)
+	pBz, err := GetCodec().Marshal(anyPb)
+	require.NoError(t, err)
+
+	require.Equal(t, pBz, bz)
+}
+
+func TestInterfaceRegistry_UnmarshalInterface(t *testing.T) {
+	registry := newInterfaceRegistry()
+
+	tp := &TestProtoStructure{
+		Field1: 1,
+		Field2: "test",
+		Field3: true,
+	}
+	var pi TestProtoInterface = tp
+
+	bz, err := registry.MarshalInterface(pi)
+	require.NoError(t, err)
+
+	// fails when iface is not a pointer
+	var newPi TestProtoInterface
+	err = registry.UnmarshalInterface(bz, newPi)
+	require.ErrorIs(t, err, ErrNotPointer)
+
+	// fails when iface is not an interface
+	err = registry.UnmarshalInterface(bz, &tp)
+	require.ErrorIs(t, err, ErrNotInterface)
+
+	// fails to unmarshal when interface is not registered
+	err = registry.UnmarshalInterface(bz, &newPi)
+	require.ErrorIs(t, err, ErrNotRegistered)
+
+	// registers an interface
+	err = registry.RegisterInterface((*TestProtoInterface)(nil))
+	require.NoError(t, err)
+
+	// fails when implementation is not registered
+	err = registry.UnmarshalInterface(bz, &newPi)
+	require.Equal(t, err, ErrImplementationNotRegistered(
+		string(proto.MessageName(tp)),
+		reflect.TypeOf((*TestProtoInterface)(nil)).Elem().Name(),
+	))
+
+	// registers an implementation
+	err = registry.RegisterImplementations(
+		(*TestProtoInterface)(nil),
+		tp,
+	)
+	require.NoError(t, err)
+
+	// unmarshals the interface
+	err = registry.UnmarshalInterface(bz, &newPi)
+	require.NoError(t, err)
+	require.Equal(t, pi.Stringify(), newPi.Stringify())
+}

--- a/shared/codec/proto/codec_test.proto
+++ b/shared/codec/proto/codec_test.proto
@@ -8,7 +8,12 @@ option go_package = "github.com/pokt-network/pocket/shared/codec";
 // proto structures in order to test the `Marhsal` and `Unmarshal` functions
 // See https://github.com/pokt-network/pocket/issues/231 for more details
 message TestProtoStructure {
-  int32 field1 = 1;
-  string field2 = 2;
-  bool field3 = 3;
+    int32 field1 = 1;
+    string field2 = 2;
+    bool field3 = 3;
+}
+
+message TestProtoStructure2 {
+    int32 field1 = 1;
+    string field2 = 2;
 }


### PR DESCRIPTION
_**NOTE**: This specific implementation is a mock, although it passes tests it may be changed depending on feedback in #906_

## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Jul 23 12:37 UTC
This pull request adds a new interface registry with the following changes:
- A new file `interface_registry.go` is added with 155 insertions.
- A new file `interface_registry_test.go` is added with 166 insertions.
- The existing file `codec_test.proto` is modified with 13 changes.

The `interface_registry.go` file contains the implementation of an interface registry that handles registration and marshaling/unmarshaling of interfaces. It provides methods for registering interfaces, registering implementations, marshaling interfaces into byte arrays, and unmarshaling byte arrays into interfaces.

The `interface_registry_test.go` file contains tests for the interface registry implementation. It tests the registration of interfaces, registration of implementations, marshaling of interfaces, and unmarshaling of interfaces.

The `codec_test.proto` file is modified by adding a new message `TestProtoStructure2`.
<!-- reviewpad:summarize:end -->

## Issue

Fixes #906 

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Adds interface registry
- Enables the registration of interfaces and their implementations
- Enables the marshalling of interfaces
- Enables the unmarshalling of marshalled interfaces back into the interface
- Adds unit tests covering the above

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
