### PR TITLE
[Persistence] Update block header

### DIFF
--- a/persistence/actor.go
+++ b/persistence/actor.go
@@ -82,7 +82,7 @@ func (p *PostgresContext) GetAllValidators(height int64) (vals []*coreTypes.Acto
 
 // GetValidatorSet returns the validator set for a given height
 func (p *PostgresContext) GetValidatorSet(height int64) (*coreTypes.ValidatorSet, error) {
-	validators, err := p.GetAllValidators(height) // sorted by address+height desc
+	validators, err := p.GetAllValidators(height) // sorted by address asc
 	if err != nil {
 		return nil, err
 	}

--- a/persistence/actor.go
+++ b/persistence/actor.go
@@ -88,12 +88,13 @@ func (p *PostgresContext) GetValidatorSet(height int64) (*coreTypes.ValidatorSet
 	}
 	valSet := new(coreTypes.ValidatorSet)
 	for _, val := range validators {
-		validator := &coreTypes.SimpleValidator{
+		validator := &coreTypes.ValidatorIdentity{
 			Address: val.GetAddress(),
 			PubKey:  val.GetPublicKey(),
 		}
 		valSet.Validators = append(valSet.Validators, validator)
 	}
+	// Assumption: Validators are sorted by address based on return value from `p.GetAllValidators`
 	return valSet, nil
 }
 

--- a/persistence/actor.go
+++ b/persistence/actor.go
@@ -92,7 +92,7 @@ func (p *PostgresContext) GetValidatorSetHash(height int64) ([]byte, error) {
 	}
 	buf := new(bytes.Buffer)
 	for _, val := range validators {
-		buf.Write([]byte(val.GetPublicKey()))
+		buf.WriteString(val.GetPublicKey())
 	}
 	valHash := crypto.SHA3Hash(buf.Bytes())
 	return valHash, nil

--- a/persistence/actor.go
+++ b/persistence/actor.go
@@ -92,7 +92,10 @@ func (p *PostgresContext) GetValidatorSetHash(height int64) ([]byte, error) {
 	}
 	buf := new(bytes.Buffer)
 	for _, val := range validators {
-		buf.WriteString(val.GetPublicKey())
+		_, err := buf.WriteString(val.GetPublicKey())
+		if err != nil {
+			return nil, err
+		}
 	}
 	valHash := crypto.SHA3Hash(buf.Bytes())
 	return valHash, nil

--- a/persistence/actor.go
+++ b/persistence/actor.go
@@ -97,30 +97,6 @@ func (p *PostgresContext) GetValidatorSet(height int64) (*coreTypes.ValidatorSet
 	return valSet, nil
 }
 
-// GetValidatorSetWithProposer returns the validator set for a given height with
-// the Proposer field set
-//
-// NOTE: This will only succeed when the block has been committed
-func (p *PostgresContext) GetValidatorSetWithProposer(height int64) (*coreTypes.ValidatorSet, error) {
-	valSet, err := p.GetValidatorSet(height)
-	if err != nil {
-		return nil, err
-	}
-	block, err := p.blockStore.GetBlock(uint64(height))
-	if err != nil {
-		return nil, err
-	}
-	proposer, err := p.GetValidator(block.BlockHeader.ProposerAddress, height)
-	if err != nil {
-		return nil, err
-	}
-	valSet.Proposer = &coreTypes.SimpleValidator{
-		Address: proposer.GetAddress(),
-		PubKey:  proposer.GetPublicKey(),
-	}
-	return valSet, nil
-}
-
 func (p *PostgresContext) GetAllServicers(height int64) (sn []*coreTypes.Actor, err error) {
 	ctx, tx := p.getCtxAndTx()
 	rows, err := tx.Query(ctx, types.ServicerActor.GetAllQuery(height))

--- a/persistence/block.go
+++ b/persistence/block.go
@@ -152,14 +152,6 @@ func (p *PostgresContext) getCurrentAndNextValSetHashes(proposerAddr []byte) (st
 	if err != nil {
 		return "", "", err
 	}
-	proposer, err := p.GetValidator(proposerAddr, p.Height-1)
-	if err != nil {
-		return "", "", err
-	}
-	valSet.Proposer = &coreTypes.SimpleValidator{
-		Address: proposer.GetAddress(),
-		PubKey:  proposer.GetPublicKey(),
-	}
 	valSetBz, err := codec.GetCodec().Marshal(valSet)
 	if err != nil {
 		return "", "", err

--- a/persistence/block.go
+++ b/persistence/block.go
@@ -86,6 +86,11 @@ func (p *PostgresContext) prepareBlock(proposerAddr, quorumCert []byte) (*coreTy
 	// TECHDEBT: This will lead to different timestamp in each node's block store because `prepareBlock` is called locally. Needs to be revisisted and decided on a proper implementation.
 	timestamp := timestamppb.Now()
 
+	valSetHash, err := p.GetValidatorSetHash(p.Height)
+	if err != nil {
+		return nil, err
+	}
+
 	// Preapre the block proto
 	blockHeader := &coreTypes.BlockHeader{
 		Height:            uint64(p.Height),
@@ -95,6 +100,8 @@ func (p *PostgresContext) prepareBlock(proposerAddr, quorumCert []byte) (*coreTy
 		ProposerAddress:   proposerAddr,
 		QuorumCertificate: quorumCert,
 		Timestamp:         timestamp,
+		StateTreeHashes:   p.stateTrees.GetTreeHashes(),
+		NextValSetHash:    hex.EncodeToString(valSetHash),
 	}
 	block := &coreTypes.Block{
 		BlockHeader:  blockHeader,

--- a/persistence/block.go
+++ b/persistence/block.go
@@ -130,7 +130,8 @@ func (p *PostgresContext) insertBlock(block *coreTypes.Block) error {
 	return err
 }
 
-func (p *PostgresContext) getCurrentAndNextValSetHashes(proposerAddr []byte) (string, string, error) {
+func (p *PostgresContext) getCurrentAndNextValSetHashes(proposerAddr []byte,
+) (currentValSetHash string, nextValSetHash string, err error) {
 	// Get the next validator set
 	nextValSet, err := p.GetValidatorSet(p.Height)
 	if err != nil {
@@ -141,7 +142,7 @@ func (p *PostgresContext) getCurrentAndNextValSetHashes(proposerAddr []byte) (st
 		return "", "", err
 	}
 	nValSetHash := crypto.SHA3Hash(nextValSetBz)
-	nextValSetHash := hex.EncodeToString(nValSetHash)
+	nextValSetHash = hex.EncodeToString(nValSetHash)
 
 	if p.Height == 0 {
 		return "", nextValSetHash, nil
@@ -157,7 +158,7 @@ func (p *PostgresContext) getCurrentAndNextValSetHashes(proposerAddr []byte) (st
 		return "", "", err
 	}
 	valSetHash := crypto.SHA3Hash(valSetBz)
-	currentValSetHash := hex.EncodeToString(valSetHash)
+	currentValSetHash = hex.EncodeToString(valSetHash)
 
 	return currentValSetHash, nextValSetHash, nil
 }

--- a/persistence/block.go
+++ b/persistence/block.go
@@ -89,7 +89,7 @@ func (p *PostgresContext) prepareBlock(proposerAddr, quorumCert []byte) (*coreTy
 	timestamp := timestamppb.Now()
 
 	// Get the current validator set and next validator set hashes
-	currSetHash, nextSetHash, err := p.getCurrentAndNextValSetHashes(proposerAddr)
+	currSetHash, nextSetHash, err := p.getCurrentAndNextValSetHashes()
 	if err != nil {
 		return nil, err
 	}
@@ -130,8 +130,7 @@ func (p *PostgresContext) insertBlock(block *coreTypes.Block) error {
 	return err
 }
 
-func (p *PostgresContext) getCurrentAndNextValSetHashes(proposerAddr []byte,
-) (currentValSetHash string, nextValSetHash string, err error) {
+func (p *PostgresContext) getCurrentAndNextValSetHashes() (currentValSetHash, nextValSetHash string, err error) {
 	// Get the next validator set
 	nextValSet, err := p.GetValidatorSet(p.Height)
 	if err != nil {

--- a/persistence/test/actor_test.go
+++ b/persistence/test/actor_test.go
@@ -1,11 +1,14 @@
 package test
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
+	"github.com/pokt-network/pocket/shared/crypto"
 )
 
 func TestGetAllStakedActors(t *testing.T) {
@@ -36,4 +39,56 @@ func TestGetAllStakedActors(t *testing.T) {
 	require.Equal(t, genesisStateNumServicers, actualServicers)
 	require.Equal(t, genesisStateNumApplications, actualApplications)
 	require.Equal(t, genesisStateNumFishermen, actualFishermen)
+}
+
+func TestGetValidatorSetHash(t *testing.T) {
+	currHeight := int64(0)
+	db := NewTestPostgresContext(t, currHeight)
+	validators, err := db.GetAllValidators(currHeight)
+	require.NoError(t, err)
+	require.Len(t, validators, genesisStateNumValidators)
+
+	buf := new(bytes.Buffer)
+	for _, val := range validators {
+		_, err := buf.WriteString(val.PublicKey)
+		require.NoError(t, err)
+	}
+	expectedHash := crypto.SHA3Hash(buf.Bytes())
+
+	actualHash, err := db.GetValidatorSetHash(currHeight)
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, actualHash)
+
+	// ensure deterministic
+	require.Equal(t, hex.EncodeToString(expectedHash), "8bc3057b495c988e831052a28946cd5e291e3b4ec51a22680fde12657a277f79")
+	require.Equal(t, hex.EncodeToString(actualHash), "8bc3057b495c988e831052a28946cd5e291e3b4ec51a22680fde12657a277f79")
+
+	// ensure hash remains the same with no changes
+	currHeight = int64(1)
+	db.Height = currHeight
+
+	actualHash, err = db.GetValidatorSetHash(currHeight)
+	require.NoError(t, err)
+	require.Equal(t, expectedHash, actualHash)
+
+	// ensure hash changes with changes
+	currHeight = int64(2)
+	db.Height = currHeight
+
+	err = db.InsertValidator(
+		[]byte("address"),
+		[]byte("publickey"),
+		[]byte("output"),
+		false, 0,
+		"serviceurl",
+		"1000000000",
+		0,
+		0,
+	)
+	require.NoError(t, err)
+
+	actualHash, err = db.GetValidatorSetHash(currHeight)
+	require.NoError(t, err)
+	require.NotEqual(t, expectedHash, actualHash)
+	require.Equal(t, hex.EncodeToString(actualHash), "560e954828499c90c5431576b78927cb0f3613435e8d302f0302113806b11d25")
 }

--- a/persistence/test/actor_test.go
+++ b/persistence/test/actor_test.go
@@ -83,7 +83,7 @@ func TestPostgresContext_GetValidatorSet(t *testing.T) {
 	require.Equal(t, expectedHashes[0], currValSetHash)
 	require.Equal(t, expectedHashes[0], nextValSetHash)
 
-	// ensure next val set hash changes when we add a new validator  at current
+	// ensure next val set hash changes when we add a new validator at current
 	// height but the current val set hash remains the same
 	currHeight = int64(3)
 	db.Height = currHeight

--- a/persistence/test/actor_test.go
+++ b/persistence/test/actor_test.go
@@ -51,6 +51,15 @@ func TestPostgresContext_GetValidatorSet(t *testing.T) {
 	db := NewTestPostgresContext(t, 0)
 	nextValSet, err := db.GetValidatorSet(0)
 	require.NoError(t, err)
+
+	// ensure validator set is ordered lexicographically
+	for i, val := range nextValSet.Validators {
+		if i == 0 {
+			continue
+		}
+		require.True(t, val.Address > nextValSet.Validators[i-1].Address)
+	}
+
 	nextValSetHash := hashValSet(t, nextValSet)
 	require.Equal(t, expectedHashes[0], nextValSetHash)
 
@@ -61,9 +70,27 @@ func TestPostgresContext_GetValidatorSet(t *testing.T) {
 
 	currValSet, err := db.GetValidatorSet(currHeight - 1)
 	require.NoError(t, err)
+
+	// ensure validator set is ordered lexicographically
+	for i, val := range currValSet.Validators {
+		if i == 0 {
+			continue
+		}
+		require.True(t, val.Address > nextValSet.Validators[i-1].Address)
+	}
+
 	currValSetHash := hashValSet(t, currValSet)
 	nextValSet, err = db.GetValidatorSet(currHeight)
 	require.NoError(t, err)
+
+	// ensure validator set is ordered lexicographically
+	for i, val := range nextValSet.Validators {
+		if i == 0 {
+			continue
+		}
+		require.True(t, val.Address > nextValSet.Validators[i-1].Address)
+	}
+
 	nextValSetHash = hashValSet(t, nextValSet)
 
 	require.Equal(t, expectedHashes[0], currValSetHash)
@@ -75,9 +102,27 @@ func TestPostgresContext_GetValidatorSet(t *testing.T) {
 
 	currValSet, err = db.GetValidatorSet(currHeight - 1)
 	require.NoError(t, err)
+
+	// ensure validator set is ordered lexicographically
+	for i, val := range currValSet.Validators {
+		if i == 0 {
+			continue
+		}
+		require.True(t, val.Address > nextValSet.Validators[i-1].Address)
+	}
+
 	currValSetHash = hashValSet(t, currValSet)
 	nextValSet, err = db.GetValidatorSet(currHeight)
 	require.NoError(t, err)
+
+	// ensure validator set is ordered lexicographically
+	for i, val := range nextValSet.Validators {
+		if i == 0 {
+			continue
+		}
+		require.True(t, val.Address > nextValSet.Validators[i-1].Address)
+	}
+
 	nextValSetHash = hashValSet(t, nextValSet)
 
 	require.Equal(t, expectedHashes[0], currValSetHash)
@@ -102,9 +147,28 @@ func TestPostgresContext_GetValidatorSet(t *testing.T) {
 
 	currValSet, err = db.GetValidatorSet(currHeight - 1)
 	require.NoError(t, err)
+
+	// ensure validator set is ordered lexicographically
+	for i, val := range currValSet.Validators {
+		if i == 0 {
+			continue
+		}
+		require.True(t, val.Address > nextValSet.Validators[i-1].Address)
+	}
+
 	currValSetHash = hashValSet(t, currValSet)
 	nextValSet, err = db.GetValidatorSet(currHeight)
 	require.NoError(t, err)
+	t.Log(nextValSet.Validators)
+
+	// ensure validator set is ordered lexicographically
+	for i, val := range currValSet.Validators {
+		if i == 0 {
+			continue
+		}
+		require.True(t, val.Address > nextValSet.Validators[i-1].Address)
+	}
+
 	nextValSetHash = hashValSet(t, nextValSet)
 
 	require.Equal(t, expectedHashes[0], currValSetHash)

--- a/persistence/trees/trees.go
+++ b/persistence/trees/trees.go
@@ -101,6 +101,16 @@ func (t *treeStore) GetTree(name string) ([]byte, kvstore.KVStore) {
 	return nil, nil
 }
 
+// GetTreeHashes returns a map of tree names to their root hashes for all
+// the trees tracked by the treestore, excluding the root tree
+func (t *treeStore) GetTreeHashes() map[string]string {
+	hashes := make(map[string]string, len(t.merkleTrees))
+	for treeName, stateTree := range t.merkleTrees {
+		hashes[treeName] = hex.EncodeToString(stateTree.tree.Root())
+	}
+	return hashes
+}
+
 // Update takes a transaction and a height and updates
 // all of the trees in the treeStore for that height.
 func (t *treeStore) Update(pgtx pgx.Tx, height uint64) (string, error) {

--- a/persistence/trees/trees_test.go
+++ b/persistence/trees/trees_test.go
@@ -17,3 +17,7 @@ func TestTreeStore_DebugClearAll(t *testing.T) {
 	// TODO: Write test case for the DebugClearAll method
 	t.Skip("TODO: Write test case for DebugClearAll method")
 }
+
+func TestTreeStore_GetTreeHashes(t *testing.T) {
+	t.Skip("TODO: Write test case for GetTreeHashes method")
+}

--- a/persistence/trees/trees_test.go
+++ b/persistence/trees/trees_test.go
@@ -19,5 +19,5 @@ func TestTreeStore_DebugClearAll(t *testing.T) {
 }
 
 func TestTreeStore_GetTreeHashes(t *testing.T) {
-	t.Skip("TODO: Write test case for GetTreeHashes method")
+	t.Skip("TODO: Write test case for GetTreeHashes method") // context: https://github.com/pokt-network/pocket/pull/915#discussion_r1267313664
 }

--- a/persistence/trees/trees_test.go
+++ b/persistence/trees/trees_test.go
@@ -18,6 +18,7 @@ func TestTreeStore_DebugClearAll(t *testing.T) {
 	t.Skip("TODO: Write test case for DebugClearAll method")
 }
 
+// TODO_AFTER(#861): Implement this test with the test suite available in #861
 func TestTreeStore_GetTreeHashes(t *testing.T) {
 	t.Skip("TODO: Write test case for GetTreeHashes method") // context: https://github.com/pokt-network/pocket/pull/915#discussion_r1267313664
 }

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -431,7 +431,9 @@ func (s *rpcServer) blockToRPCBlock(protoBlock *coreTypes.Block) (*Block, error)
 				},
 				Transactions: qcTxs,
 			},
-			Timestamp: protoBlock.BlockHeader.GetTimestamp().AsTime().String(),
+			Timestamp:       protoBlock.BlockHeader.GetTimestamp().AsTime().String(),
+			StateTreeHashes: BlockHeader_StateTreeHashes{protoBlock.BlockHeader.GetStateTreeHashes()},
+			NextValSetHash:  protoBlock.BlockHeader.GetNextValSetHash(),
 		},
 		Transactions: txs,
 	}, nil

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -433,6 +433,7 @@ func (s *rpcServer) blockToRPCBlock(protoBlock *coreTypes.Block) (*Block, error)
 			},
 			Timestamp:       protoBlock.BlockHeader.GetTimestamp().AsTime().String(),
 			StateTreeHashes: BlockHeader_StateTreeHashes{protoBlock.BlockHeader.GetStateTreeHashes()},
+			ValSetHash:      protoBlock.BlockHeader.GetValSetHash(),
 			NextValSetHash:  protoBlock.BlockHeader.GetNextValSetHash(),
 		},
 		Transactions: txs,

--- a/rpc/v1/openapi.yaml
+++ b/rpc/v1/openapi.yaml
@@ -1501,6 +1501,8 @@ components:
         - proposer_addr
         - quorum_cert
         - timestamp
+        - state_tree_hashes
+        - next_val_set_hash
       properties:
         height:
           type: integer
@@ -1516,6 +1518,12 @@ components:
         quorum_cert:
           $ref: "#/components/schemas/QuorumCertificate"
         timestamp:
+          type: string
+        state_tree_hashes:
+          type: object
+          additionalProperties:
+            type: string
+        next_val_set_hash:
           type: string
     Coin:
       type: object

--- a/rpc/v1/openapi.yaml
+++ b/rpc/v1/openapi.yaml
@@ -1502,6 +1502,7 @@ components:
         - quorum_cert
         - timestamp
         - state_tree_hashes
+        - val_set_hash
         - next_val_set_hash
       properties:
         height:
@@ -1523,6 +1524,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        val_set_hash:
+          type: string
         next_val_set_hash:
           type: string
     Coin:

--- a/shared/core/types/proto/block.proto
+++ b/shared/core/types/proto/block.proto
@@ -15,10 +15,21 @@ message BlockHeader {
   bytes quorumCertificate = 6; // the quorum certificate containing signature from 2/3+ validators at this height
   google.protobuf.Timestamp timestamp = 7; // unixnano timestamp of when the block was created
   map<string, string> state_tree_hashes = 8; // map[TreeName]hex(TreeRootHash)
-  string next_val_set_hash = 9; // the hash of the next validator set; needed to ensure the validity of staked validators proposing the next block
+  string val_set_hash = 9; // the hash of the current validator set who were able to sign the current block
+  string next_val_set_hash = 10; // the hash of the next validator set; needed to ensure the validity of staked validators proposing the next block
 }
 
 message Block {
   core.BlockHeader blockHeader = 1;
   repeated bytes transactions = 2;
+}
+
+message ValidatorSet {
+    repeated SimpleValidator validators = 1;
+    SimpleValidator proposer = 2;
+}
+
+message SimpleValidator {
+    string address = 1;
+    string pub_key = 2;
 }

--- a/shared/core/types/proto/block.proto
+++ b/shared/core/types/proto/block.proto
@@ -25,10 +25,10 @@ message Block {
 }
 
 message ValidatorSet {
-    repeated SimpleValidator validators = 1;
+    repeated ValidatorIdentity validators = 1;
 }
 
-message SimpleValidator {
+message ValidatorIdentity {
     string address = 1;
     string pub_key = 2;
 }

--- a/shared/core/types/proto/block.proto
+++ b/shared/core/types/proto/block.proto
@@ -13,7 +13,9 @@ message BlockHeader {
   string prevStateHash = 4; // the state committment at this block height-1
   bytes proposerAddress = 5; // the address of the proposer of this block; TECHDEBT: Change this to an string
   bytes quorumCertificate = 6; // the quorum certificate containing signature from 2/3+ validators at this height
-  google.protobuf.Timestamp timestamp = 7; // CONSIDERATION: Is this needed?
+  google.protobuf.Timestamp timestamp = 7; // unixnano timestamp of when the block was created
+  map<string, string> state_tree_hashes = 8; // map[TreeName]hex(TreeRootHash)
+  string next_val_set_hash = 9; // the hash of the next validator set
 }
 
 message Block {

--- a/shared/core/types/proto/block.proto
+++ b/shared/core/types/proto/block.proto
@@ -15,7 +15,7 @@ message BlockHeader {
   bytes quorumCertificate = 6; // the quorum certificate containing signature from 2/3+ validators at this height
   google.protobuf.Timestamp timestamp = 7; // unixnano timestamp of when the block was created
   map<string, string> state_tree_hashes = 8; // map[TreeName]hex(TreeRootHash)
-  string next_val_set_hash = 9; // the hash of the next validator set
+  string next_val_set_hash = 9; // the hash of the next validator set; needed to ensure the validity of staked validators proposing the next block
 }
 
 message Block {

--- a/shared/core/types/proto/block.proto
+++ b/shared/core/types/proto/block.proto
@@ -28,6 +28,8 @@ message ValidatorSet {
     repeated ValidatorIdentity validators = 1;
 }
 
+// DISCUSS(M5): Should we include voting power in this identity?
+// Ignoring voting_power/stake for leader election? Is this needed - I dont think so
 message ValidatorIdentity {
     string address = 1;
     string pub_key = 2;

--- a/shared/core/types/proto/block.proto
+++ b/shared/core/types/proto/block.proto
@@ -26,7 +26,6 @@ message Block {
 
 message ValidatorSet {
     repeated SimpleValidator validators = 1;
-    SimpleValidator proposer = 2;
 }
 
 message SimpleValidator {

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -224,7 +224,6 @@ type PersistenceReadContext interface {
 	GetValidator(address []byte, height int64) (*coreTypes.Actor, error)
 	GetAllValidators(height int64) ([]*coreTypes.Actor, error)
 	GetValidatorSet(height int64) (*coreTypes.ValidatorSet, error)
-	GetValidatorSetWithProposer(height int64) (*coreTypes.ValidatorSet, error) // only works when block has been commited
 	GetValidatorExists(address []byte, height int64) (exists bool, err error)
 	GetValidatorStakeAmount(height int64, address []byte) (string, error)
 	GetValidatorsReadyToUnstake(height int64, status int32) (validators []*moduleTypes.UnstakingActor, err error)

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -223,6 +223,8 @@ type PersistenceReadContext interface {
 	// Validator Queries
 	GetValidator(address []byte, height int64) (*coreTypes.Actor, error)
 	GetAllValidators(height int64) ([]*coreTypes.Actor, error)
+	GetValidatorSet(height int64) (*coreTypes.ValidatorSet, error)
+	GetValidatorSetWithProposer(height int64) (*coreTypes.ValidatorSet, error) // only works when block has been commited
 	GetValidatorExists(address []byte, height int64) (exists bool, err error)
 	GetValidatorStakeAmount(height int64, address []byte) (string, error)
 	GetValidatorsReadyToUnstake(height int64, status int32) (validators []*moduleTypes.UnstakingActor, err error)

--- a/shared/modules/treestore_module.go
+++ b/shared/modules/treestore_module.go
@@ -32,4 +32,6 @@ type TreeStoreModule interface {
 	DebugClearAll() error
 	// GetTree returns the specified tree's root and nodeStore in order to be imported elsewhere
 	GetTree(name string) ([]byte, kvstore.KVStore)
+	// GetTreeHashes returns a map of tree names to their root hashes
+	GetTreeHashes() map[string]string
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jul 23 20:52 UTC
This pull request includes the following changes:
- Added a new function `GetTreeHashes` in the `trees.go` file.
- Added import statements in various files.
- Added functions and tests related to preparing and inserting blocks, getting validator set hashes, and hashing validator set.
- Added a test function `TestTreeStore_GetTreeHashes` in the `trees_test.go` file.
- Made changes to the `block.proto` file including updating the `BlockHeader` message, adding the `ValidatorSet` message, and adding the `ValidatorIdentity` message.
- Added a method `GetTreeHashes` in the `treestore_module.go` file.
- Made changes to the `openapi.yaml` file related to the "Block" schema.
- Added a new function `GetValidatorSet` in the `actor.go` file.
- Made changes to the `actor_test.go` file related to importing packages and adding test functions.
- Made changes to the `rpc/utils.go` file related to adding fields to the `BlockHeader` struct in the `blockToRPCBlock` function.
- Added a new method `GetValidatorSet` to the `PersistenceReadContext` interface in the `persistence_module.go` file.
<!-- reviewpad:summarize:end -->

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Adds state tree hashes as a map to the block header
- Add next validator set hash to the block header

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made


## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
