### PR TITLE
[Consensus] Add Nil Check Before Calling Method in Hotstuff Handler

### DIFF
--- a/consensus/hotstuff_handler.go
+++ b/consensus/hotstuff_handler.go
@@ -29,7 +29,7 @@ func (m *consensusModule) handleHotstuffMessage(msg *typesCons.HotstuffMessage) 
 	m.logger.Debug().Fields(loggingFields).Msg("About to start handling hotstuff msg...")
 
 	// Elect a leader for the current round if needed
-	if m.shouldElectNextLeader() {
+	if m != nil && m.shouldElectNextLeader() {
 		if err := m.electNextLeader(msg); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Problem

Currently, in the `hotstuff_handler.go` file, we're calling a method on a variable `m` without first checking if `m` is `nil`. Specifically, in the line with `if m.shouldElectNextLeader() {`, if `m` is `nil`, this will cause a runtime panic.

## Solution

To prevent this, we can add a nil check before calling the method. So, instead of `if m.shouldElectNextLeader() {`, we can use `if m != nil && m.shouldElectNextLeader() {`. This will ensure that the method is only called if `m` is not `nil`, preventing a potential runtime panic.

## What This Pull Request Changes

This pull request adds a nil check before a method call in `hotstuff_handler.go` to prevent a potential runtime panic.