### PR TITLE
[IBC] chore: Rename FlushAllEntries => FlushCachesToStore

### DIFF
--- a/ibc/ibc_handle_event_test.go
+++ b/ibc/ibc_handle_event_test.go
@@ -81,7 +81,7 @@ func TestHandleEvent_FlushCaches(t *testing.T) {
 	require.NoError(t, cache.Stop())
 
 	// flush the cache
-	err = ibcHost.GetBus().GetBulkStoreCacher().FlushAllEntries()
+	err = ibcHost.GetBus().GetBulkStoreCacher().FlushCachesToStore()
 	require.NoError(t, err)
 
 	cache, err = kvstore.NewKVStore(tmpDir)

--- a/ibc/module.go
+++ b/ibc/module.go
@@ -95,7 +95,7 @@ func (m *ibcModule) HandleEvent(event *anypb.Any) error {
 		}
 		// Flush all caches to disk for last height
 		bsc := m.GetBus().GetBulkStoreCacher()
-		if err := bsc.FlushAllEntries(); err != nil {
+		if err := bsc.FlushCachesToStore(); err != nil {
 			return err
 		}
 		// Prune old cache entries

--- a/ibc/store/bulk_store_cache.go
+++ b/ibc/store/bulk_store_cache.go
@@ -124,8 +124,8 @@ func (s *bulkStoreCache) GetAllStores() map[string]modules.ProvableStore {
 	return s.ls.stores
 }
 
-// FlushAllEntries caches all the entries for all stores in the bulkStoreCache
-func (s *bulkStoreCache) FlushAllEntries() error {
+// FlushdCachesToStore caches all the entries for all stores in the bulkStoreCache
+func (s *bulkStoreCache) FlushCachesToStore() error {
 	s.ls.m.Lock()
 	defer s.ls.m.Unlock()
 	s.logger.Info().Msg("🚽 Flushing All Cache Entries to Disk 🚽")
@@ -134,7 +134,7 @@ func (s *bulkStoreCache) FlushAllEntries() error {
 		return err
 	}
 	for _, store := range s.ls.stores {
-		if err := store.FlushEntries(disk); err != nil {
+		if err := store.FlushCache(disk); err != nil {
 			s.logger.Error().Err(err).Str("store", string(store.GetCommitmentPrefix())).Msg("🚨 Error Flushing Cache 🚨")
 			return err
 		}

--- a/ibc/store/provable_store.go
+++ b/ibc/store/provable_store.go
@@ -166,8 +166,8 @@ func (p *provableStore) Root() ics23.CommitmentRoot {
 	return root
 }
 
-// FlushEntries writes all local changes to disk and clears the in-memory cache
-func (p *provableStore) FlushEntries(store kvstore.KVStore) error {
+// FlushCache writes all local changes to disk and clears the in-memory cache
+func (p *provableStore) FlushCache(store kvstore.KVStore) error {
 	p.m.Lock()
 	defer p.m.Unlock()
 	for _, entry := range p.cache {

--- a/ibc/store/provable_store_test.go
+++ b/ibc/store/provable_store_test.go
@@ -148,7 +148,7 @@ func TestProvableStore_GetAndProve(t *testing.T) {
 	}
 }
 
-func TestProvableStore_FlushEntries(t *testing.T) {
+func TestProvableStore_FlushCache(t *testing.T) {
 	provableStore := newTestProvableStore(t)
 	kvs := []struct {
 		key   []byte
@@ -177,7 +177,7 @@ func TestProvableStore_FlushEntries(t *testing.T) {
 		}
 	}
 	cache := kvstore.NewMemKVStore()
-	require.NoError(t, provableStore.FlushEntries(cache))
+	require.NoError(t, provableStore.FlushCache(cache))
 	keys, values, err := cache.GetAll([]byte{}, false)
 	require.NoError(t, err)
 	require.Len(t, keys, 3)
@@ -221,7 +221,7 @@ func TestProvableStore_PruneCache(t *testing.T) {
 		}
 	}
 	cache := kvstore.NewMemKVStore()
-	require.NoError(t, provableStore.FlushEntries(cache))
+	require.NoError(t, provableStore.FlushCache(cache))
 	keys, _, err := cache.GetAll([]byte{}, false)
 	require.NoError(t, err)
 	require.Len(t, keys, 3) // 3 entries in cache should be flushed to disk
@@ -264,12 +264,12 @@ func TestProvableStore_RestoreCache(t *testing.T) {
 	}
 
 	cache := kvstore.NewMemKVStore()
-	require.NoError(t, provableStore.FlushEntries(cache))
+	require.NoError(t, provableStore.FlushCache(cache))
 	keys, values, err := cache.GetAll([]byte{}, false)
 	require.NoError(t, err)
 	require.Len(t, keys, 3)
 	require.NoError(t, cache.ClearAll())
-	require.NoError(t, provableStore.FlushEntries(cache))
+	require.NoError(t, provableStore.FlushCache(cache))
 	newKeys, _, err := cache.GetAll([]byte{}, false)
 	require.NoError(t, err)
 	require.Len(t, newKeys, 0)
@@ -284,7 +284,7 @@ func TestProvableStore_RestoreCache(t *testing.T) {
 	newKeys, _, err = cache.GetAll([]byte{}, false)
 	require.NoError(t, err)
 	require.Len(t, newKeys, 0)
-	require.NoError(t, provableStore.FlushEntries(cache))
+	require.NoError(t, provableStore.FlushCache(cache))
 	newKeys, newValues, err := cache.GetAll([]byte{}, false)
 	require.NoError(t, err)
 	require.Len(t, newKeys, 3)

--- a/internal/testutil/ibc/mock.go
+++ b/internal/testutil/ibc/mock.go
@@ -74,7 +74,7 @@ func baseBulkStoreCacherMock(t gocuke.TestingT, bus modules.Bus) *mockModules.Mo
 	storeMock.EXPECT().AddStore(gomock.Any()).Return(nil).AnyTimes()
 	storeMock.EXPECT().GetStore(gomock.Any()).Return(provableStoreMock, nil).AnyTimes()
 	storeMock.EXPECT().RemoveStore(gomock.Any()).Return(nil).AnyTimes()
-	storeMock.EXPECT().FlushAllEntries().Return(nil).AnyTimes()
+	storeMock.EXPECT().FlushCachesToStore().Return(nil).AnyTimes()
 	storeMock.EXPECT().PruneCaches(gomock.Any()).Return(nil).AnyTimes()
 	storeMock.EXPECT().RestoreCaches(gomock.Any()).Return(nil).AnyTimes()
 

--- a/shared/modules/ibc_store_module.go
+++ b/shared/modules/ibc_store_module.go
@@ -25,7 +25,7 @@ type BulkStoreCacher interface {
 	GetStore(name string) (ProvableStore, error)
 	RemoveStore(name string) error
 	GetAllStores() map[string]ProvableStore
-	FlushAllEntries() error
+	FlushCachesToStore() error
 	PruneCaches(height uint64) error
 	RestoreCaches(height uint64) error
 }
@@ -44,7 +44,7 @@ type ProvableStore interface {
 	Delete(key []byte) error
 	GetCommitmentPrefix() coreTypes.CommitmentPrefix
 	Root() ics23.CommitmentRoot
-	FlushEntries(kvstore.KVStore) error
+	FlushCache(kvstore.KVStore) error
 	PruneCache(store kvstore.KVStore, height uint64) error
 	RestoreCache(store kvstore.KVStore, height uint64) error
 }


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Jul 23 15:58 UTC
This pull request renames the `FlushAllEntries` function to `FlushCachesToStore` in multiple files. The function is responsible for flushing the cache entries for all stores in the `bulkStoreCache` struct. The renaming is consistent across the affected files, including `ibc_handle_event_test.go`, `module.go`, `bulk_store_cache.go`, `provable_store.go`, `provable_store_test.go`, `mock.go`, and `ibc_store_module.go`. The patch also includes some code formatting changes.
<!-- reviewpad:summarize:end -->

## Issue

Fixes https://github.com/pokt-network/pocket/pull/868/files#r1262167821

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Rename `FlushAllEntries` to `FlushCachesToStore`
- Rename `FlushEntries` to `FlushCache`

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
