### PR TITLE
[Persistence] Adds `node` subcommand to CLI

### DIFF
--- a/app/client/cli/node.go
+++ b/app/client/cli/node.go
@@ -1,0 +1,18 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func init() {
+	nodeCmd := NewNodeCommand()
+	rootCmd.AddCommand(nodeCmd)
+}
+
+func NewNodeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "Node",
+		Short:   "Commands related to node management and operations",
+		Aliases: []string{"node", "n"},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
## Description

Adds the first step of the CLI harness for save and load E2E testing. This PR is the first of a series and will be followed by additional PRs adding the actual sub-command logic and execution. 

`node` keyword was chosen contrary to #566 as per the Discussion in Discord.

<img width="1030" alt="image" src="https://github.com/pokt-network/pocket/assets/5915948/e8d0cc1a-3ad2-4e09-8638-220159c9743e">

## Issue

Relates to a series of changes to address #566

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Adds the `node` sub-command to the app CLI.

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
