### PR TITLE
[Utility] Use TreeStore as source of truth

### DIFF
--- a/persistence/block.go
+++ b/persistence/block.go
@@ -1,11 +1,11 @@
 package persistence
 
 import (
+	"bytes"
 	"encoding/hex"
-	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/pokt-network/pocket/persistence/trees"
 	"github.com/pokt-network/pocket/persistence/types"
 	"github.com/pokt-network/pocket/shared/codec"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
@@ -13,21 +13,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func (p *persistenceModule) TransactionExists(transactionHash string) (bool, error) {
-	hash, err := hex.DecodeString(transactionHash)
-	if err != nil {
-		return false, err
+func (p *persistenceModule) TransactionExists(txHash, txProtoBz []byte) bool {
+	exists := p.GetBus().GetTreeStore().Prove(trees.TransactionsTreeName, txHash, txProtoBz)
+	if bytes.Equal(txProtoBz, nil) && exists == nil {
+		return false
 	}
-	res, err := p.txIndexer.GetByHash(hash)
-	if res == nil {
-		// check for not found
-		if err != nil && errors.Is(err, badger.ErrKeyNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
+	return exists == nil
 }
 
 func (p *PostgresContext) GetMinimumBlockHeight() (latestHeight uint64, err error) {

--- a/persistence/trees/trees.go
+++ b/persistence/trees/trees.go
@@ -106,21 +106,19 @@ func (t *treeStore) GetTree(name string) ([]byte, kvstore.KVStore) {
 // Prove generates and verifies a proof against the tree name stored in the TreeStore
 // using the given key-value pair. If value == nil this will be an exclusion proof,
 // otherwise it will be an inclusion proof.
-//
-// If the proof is valid, nil is returned. Otherwise, an error is returned.
-func (t *treeStore) Prove(name string, key, value []byte) error {
+func (t *treeStore) Prove(name string, key, value []byte) (bool, error) {
 	st, ok := t.merkleTrees[name]
 	if !ok {
-		return fmt.Errorf("tree not found: %s", name)
+		return false, fmt.Errorf("tree not found: %s", name)
 	}
 	proof, err := st.tree.Prove(key)
 	if err != nil {
-		return fmt.Errorf("error generating proof (%s): %w", name, err)
+		return false, fmt.Errorf("error generating proof (%s): %w", name, err)
 	}
 	if valid := smt.VerifyProof(proof, st.tree.Root(), key, value, st.tree.Spec()); !valid {
-		return fmt.Errorf("invalid proof for key: %s, value: %s (%s)", hex.EncodeToString(key), hex.EncodeToString(value), name)
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
 // GetTreeHashes returns a map of tree names to their root hashes for all

--- a/persistence/trees/trees_test.go
+++ b/persistence/trees/trees_test.go
@@ -1,7 +1,6 @@
 package trees
 
 import (
-	"encoding/hex"
 	"fmt"
 	"testing"
 
@@ -53,20 +52,23 @@ func TestTreeStore_Prove(t *testing.T) {
 		treeName    string
 		key         []byte
 		value       []byte
+		valid       bool
 		expectedErr error
 	}{
 		{
-			name:        "valid proof: key and value in tree",
+			name:        "valid inclusion proof: key and value in tree",
 			treeName:    "test",
 			key:         []byte("key"),
 			value:       []byte("value"),
+			valid:       true,
 			expectedErr: nil,
 		},
 		{
-			name:        "valid proof: key not in tree",
+			name:        "valid exclusion proof: key not in tree",
 			treeName:    "test",
 			key:         []byte("key2"),
 			value:       nil,
+			valid:       true,
 			expectedErr: nil,
 		},
 		{
@@ -74,27 +76,31 @@ func TestTreeStore_Prove(t *testing.T) {
 			treeName:    "unstored tree",
 			key:         []byte("key"),
 			value:       []byte("value"),
+			valid:       false,
 			expectedErr: fmt.Errorf("tree not found: %s", "unstored tree"),
 		},
 		{
-			name:        "invalid proof: key in tree, wrong value",
+			name:        "invalid inclusion proof: key in tree, wrong value",
 			treeName:    "test",
 			key:         []byte("key"),
 			value:       []byte("wrong value"),
-			expectedErr: fmt.Errorf("invalid proof for key: %s, value: %s (%s)", hex.EncodeToString([]byte("key")), hex.EncodeToString([]byte("wrong value")), "test"),
+			valid:       false,
+			expectedErr: nil,
 		},
 		{
-			name:        "invalid proof: key in tree",
+			name:        "invalid exclusion proof: key in tree",
 			treeName:    "test",
 			key:         []byte("key"),
 			value:       nil,
-			expectedErr: fmt.Errorf("invalid proof for key: %s, value: %s (%s)", hex.EncodeToString([]byte("key")), hex.EncodeToString([]byte(nil)), "test"),
+			valid:       false,
+			expectedErr: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := treeStore.Prove(tc.treeName, tc.key, tc.value)
+			valid, err := treeStore.Prove(tc.treeName, tc.key, tc.value)
+			require.Equal(t, valid, tc.valid)
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
 				return

--- a/persistence/trees/trees_test.go
+++ b/persistence/trees/trees_test.go
@@ -1,6 +1,14 @@
 package trees
 
-import "testing"
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/pokt-network/pocket/persistence/kvstore"
+	"github.com/pokt-network/smt"
+	"github.com/stretchr/testify/require"
+)
 
 // TECHDEBT(#836): Tests added in https://github.com/pokt-network/pocket/pull/836
 func TestTreeStore_Update(t *testing.T) {
@@ -21,4 +29,77 @@ func TestTreeStore_DebugClearAll(t *testing.T) {
 // TODO_AFTER(#861): Implement this test with the test suite available in #861
 func TestTreeStore_GetTreeHashes(t *testing.T) {
 	t.Skip("TODO: Write test case for GetTreeHashes method") // context: https://github.com/pokt-network/pocket/pull/915#discussion_r1267313664
+}
+
+func TestTreeStore_Prove(t *testing.T) {
+	nodeStore := kvstore.NewMemKVStore()
+	tree := smt.NewSparseMerkleTree(nodeStore, smtTreeHasher)
+	testTree := &stateTree{
+		name:      "test",
+		tree:      tree,
+		nodeStore: nodeStore,
+	}
+
+	require.NoError(t, testTree.tree.Update([]byte("key"), []byte("value")))
+	require.NoError(t, testTree.tree.Commit())
+
+	treeStore := &treeStore{
+		merkleTrees: make(map[string]*stateTree, 1),
+	}
+	treeStore.merkleTrees["test"] = testTree
+
+	testCases := []struct {
+		name        string
+		treeName    string
+		key         []byte
+		value       []byte
+		expectedErr error
+	}{
+		{
+			name:        "valid proof: key and value in tree",
+			treeName:    "test",
+			key:         []byte("key"),
+			value:       []byte("value"),
+			expectedErr: nil,
+		},
+		{
+			name:        "valid proof: key not in tree",
+			treeName:    "test",
+			key:         []byte("key2"),
+			value:       nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "invalid proof: tree not in store",
+			treeName:    "unstored tree",
+			key:         []byte("key"),
+			value:       []byte("value"),
+			expectedErr: fmt.Errorf("tree not found: %s", "unstored tree"),
+		},
+		{
+			name:        "invalid proof: key in tree, wrong value",
+			treeName:    "test",
+			key:         []byte("key"),
+			value:       []byte("wrong value"),
+			expectedErr: fmt.Errorf("invalid proof for key: %s, value: %s (%s)", hex.EncodeToString([]byte("key")), hex.EncodeToString([]byte("wrong value")), "test"),
+		},
+		{
+			name:        "invalid proof: key in tree",
+			treeName:    "test",
+			key:         []byte("key"),
+			value:       nil,
+			expectedErr: fmt.Errorf("invalid proof for key: %s, value: %s (%s)", hex.EncodeToString([]byte("key")), hex.EncodeToString([]byte(nil)), "test"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := treeStore.Prove(tc.treeName, tc.key, tc.value)
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorAs(t, err, &tc.expectedErr)
+		})
+	}
 }

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -33,7 +33,7 @@ type PersistenceModule interface {
 
 	// Indexer operations
 	GetTxIndexer() indexer.TxIndexer
-	TransactionExists(transactionHash string) (bool, error)
+	TransactionExists(txHash, txProtoBz []byte) bool
 
 	// Debugging / development only
 	HandleDebugMessage(*messaging.DebugMessage) error

--- a/shared/modules/persistence_module.go
+++ b/shared/modules/persistence_module.go
@@ -33,7 +33,9 @@ type PersistenceModule interface {
 
 	// Indexer operations
 	GetTxIndexer() indexer.TxIndexer
-	TransactionExists(txHash, txProtoBz []byte) bool
+
+	// TreeStore operations
+	TransactionExists(txHash, txProtoBz []byte) (bool, error)
 
 	// Debugging / development only
 	HandleDebugMessage(*messaging.DebugMessage) error

--- a/shared/modules/treestore_module.go
+++ b/shared/modules/treestore_module.go
@@ -33,7 +33,7 @@ type TreeStoreModule interface {
 	DebugClearAll() error
 	// Prove generates and verifies a proof against the tree with the matching name using the given
 	// key and value. If value == nil, it will verify non-membership of the key, otherwise membership.
-	Prove(treeName string, key, value []byte) error
+	Prove(treeName string, key, value []byte) (bool, error)
 	// GetTree returns the specified tree's root and nodeStore in order to be imported elsewhere
 	GetTree(name string) ([]byte, kvstore.KVStore)
 	// GetTreeHashes returns a map of tree names to their root hashes

--- a/shared/modules/treestore_module.go
+++ b/shared/modules/treestore_module.go
@@ -31,6 +31,9 @@ type TreeStoreModule interface {
 	Update(pgtx pgx.Tx, height uint64) (string, error)
 	// DebugClearAll completely clears the state of the trees. For debugging purposes only.
 	DebugClearAll() error
+	// Prove generates and verifies a proof against the tree with the matching name using the given
+	// key and value. If value == nil, it will verify non-membership of the key, otherwise membership.
+	Prove(treeName string, key, value []byte) error
 	// GetTree returns the specified tree's root and nodeStore in order to be imported elsewhere
 	GetTree(name string) ([]byte, kvstore.KVStore)
 	// GetTreeHashes returns a map of tree names to their root hashes

--- a/utility/transaction.go
+++ b/utility/transaction.go
@@ -20,7 +20,10 @@ func (u *utilityModule) HandleTransaction(txProtoBytes []byte) error {
 	}
 
 	// Is the tx already committed & indexed (on disk)?
-	if txExists := u.GetBus().GetPersistenceModule().TransactionExists(txHash, txProtoBytes); txExists {
+	txExists, err := u.GetBus().GetPersistenceModule().TransactionExists(txHash, txProtoBytes)
+	if err != nil {
+		return err
+	} else if txExists {
 		return coreTypes.ErrTransactionAlreadyCommitted()
 	}
 

--- a/utility/transaction.go
+++ b/utility/transaction.go
@@ -7,21 +7,20 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	"github.com/pokt-network/pocket/shared/codec"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
+	"github.com/pokt-network/pocket/shared/crypto"
 )
 
 // HandleTransaction implements the exposed functionality of the shared utilityModule interface.
 func (u *utilityModule) HandleTransaction(txProtoBytes []byte) error {
-	txHash := coreTypes.TxHash(txProtoBytes)
+	txHash := crypto.SHA3Hash(txProtoBytes)
 
 	// Is the tx already in the mempool (in memory)?
-	if u.mempool.Contains(txHash) {
+	if u.mempool.Contains(hex.EncodeToString(txHash)) {
 		return coreTypes.ErrDuplicateTransaction()
 	}
 
 	// Is the tx already committed & indexed (on disk)?
-	if txExists, err := u.GetBus().GetPersistenceModule().TransactionExists(txHash); err != nil {
-		return err
-	} else if txExists {
+	if txExists := u.GetBus().GetPersistenceModule().TransactionExists(txHash, txProtoBytes); txExists {
 		return coreTypes.ErrTransactionAlreadyCommitted()
 	}
 


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 11:24 UTC
This pull request includes the following changes:
1. In the `trees.go` file:
   - Added a new method `Prove` that generates and verifies a proof against a tree name stored in the `TreeStore`.
   - Updated the `GetTreeHashes` method to exclude the root tree from the map of tree names to their root hashes.
   
2. In the `treestore_module.go` file:
   - Added a new method `Prove` that generates and verifies a proof against a tree with a matching name.
   - No other changes have been made to the existing methods in the file.

3. In the `transaction_test.go` file:
   - Modified the import statements to use different package names.
   - Modified the test cases `TestHandleTransaction_ErrorAlreadyInMempool`, `TestHandleTransaction_ErrorAlreadyCommitted`, and `TestHandleTransaction_BasicValidation`.
   - Modified the function `prepareEmptyIndexedTransaction`.
   - Changed some variable names.

4. In the `ibc_msg_mempool_test.go` file:
   - Added a new test function `TestHandleMessage_ErrorAlreadyCommitted`.
   - Added environment preparation code, code for indexing a test transaction, and handling the error.
   - Modified the error handling code.

5. In the `utility/transaction.go` file:
   - Added an import statement for the `github.com/pokt-network/pocket/shared/crypto` package.
   - Updated the assignment of the `txHash` variable.
   - Updated the condition for checking if the transaction is already in the mempool.
   - Updated the call to `u.GetBus().GetPersistenceModule().TransactionExists`.
   - Updated the check for the existence of the transaction.

6. In the `persistence/trees/trees_test.go` file:
   - Updated the package imports.
   - Added a new test function `TestTreeStore_Prove` and several test cases.
   - Updated the `treeStore` struct and the existing test function.

7. In the `persistence_module.go` file:
   - Added a new method `TransactionExists` and commented out the old method.

Please let me know if you would like a more detailed review of any specific part of the diff.
<!-- reviewpad:summarize:end -->

## Issue

Fixes #875 

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Update `TransactionExists` to use TreeStore
- Add `Prove` method to TreeStore
- Update tests

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
