### PR TITLE
[IBC] chore: enable IBC module in k8s validators

### DIFF
--- a/charts/pocket/README.md
+++ b/charts/pocket/README.md
@@ -44,6 +44,9 @@ privateKeySecretKeyRef:
 | config.consensus.pacemaker_config.timeout_msec | int | `10000` |  |
 | config.consensus.private_key | string | `""` |  |
 | config.fisherman.enabled | bool | `false` |  |
+| config.ibc.enabled | bool | `true` |  |
+| config.ibc.host.private_key | string | `""` |  |
+| config.ibc.stores_dir | string | `"/pocket/data/ibc"` |  |
 | config.logger.format | string | `"json"` |  |
 | config.logger.level | string | `"debug"` |  |
 | config.p2p.hostname | string | `""` |  |

--- a/charts/pocket/values.yaml
+++ b/charts/pocket/values.yaml
@@ -117,6 +117,11 @@ config:
     enabled: false
   fisherman:
     enabled: false
+  ibc:
+    enabled: true
+    stores_dir: "/pocket/data/ibc"
+    host:
+      private_key: "" # @ignored This value is needed but ignored - use privateKeySecretKeyRef instead
 
 genesis:
   preProvisionedGenesis:


### PR DESCRIPTION
## Description

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Jul 23 22:08 UTC
This pull request includes two commits. 

The first commit enables the IBC module in the k8s validators. It adds new configurations for the IBC module and sets it to enabled. It also specifies the stores directory and the private key for the host. 

The second commit adds generated helm documentation to the pocket charts. It modifies the README.md file to include documentation for the configuration settings related to the IBC module.

Overall, these changes enable the IBC module in k8s validators and provide documentation for it in the helm charts.
<!-- reviewpad:summarize:end -->

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Enable IBC module in k8s validators

## Testing

- [x] `make develop_test`; if any code changes were made
- [x] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [x] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [x] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [x] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
