### PR TITLE
[Chore][WIP] Adds assertions to rollback error path test

### DIFF
--- a/persistence/context.go
+++ b/persistence/context.go
@@ -46,10 +46,9 @@ func (p *PostgresContext) SetSavePoint() error {
 
 // RollbackToSavepoint triggers a rollback for the current pgx transaction and the underylying submodule stores.
 func (p *PostgresContext) RollbackToSavePoint() error {
-	ctx, _ := p.getCtxAndTx()
-	pgErr := p.tx.Rollback(ctx)
-	treesErr := p.stateTrees.Rollback()
-	return errors.Join(pgErr, treesErr)
+	err := p.stateTrees.Rollback()
+	p.Release()
+	return err
 }
 
 // Full details in the thread from the PR review: https://github.com/pokt-network/pocket/pull/285#discussion_r1018471719


### PR DESCRIPTION
## Description

This PR captures the update to the rollback error path, with regard to the create and release lifecycle for a `RWContext` in a pocket node.

## Issue

Related to #861 

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- adds a test for the error path of the treeStore when a rollback fails

## Testing

- [ ] `make develop_test`; if any code changes were made
- [ ] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
