### PR TITLE
[Development] Add LocalDev pod debugging

### DIFF
--- a/build/localnet/README.md
+++ b/build/localnet/README.md
@@ -206,6 +206,32 @@ The k8s manifests that `tilt` submits to the cluster can be found in [this direc
 
 Tilt continuously monitors files on local filesystem in [specific directories](Tiltfile#L27), and it rebuilds the binary and distributes it to the pods on every code change. This allows developers to iterate on the code and see the changes immediately (i.e. hot-reloading).
 
+## Connect to a pod debugging server
+
+LocalNet pocket nodes have a dlv debugging server opened on port 7081. In order to connect a debugging client (VSCode, GoLand) and be able to set breakpoints, we need to setup a tunnel with the pod we want to debug.
+
+```
+kubectl port-forward validator-001-pocket-0 7081:7081
+```
+
+### Configure VSCode debugger
+
+Add the following to VSCode `launch.json` configuration
+
+```
+{
+  "name": "Debug Pocket Node",
+  "type": "go",
+  "request": "attach",
+  "mode": "remote",
+  "remotePath": "${workspaceFolder}",
+  "port": 7081,
+  "host": "localhost"
+}
+```
+
+Then you have just to set your breakpoints and start the debugging session (no need to rebuild or restart the binary).
+
 ## Troubleshooting
 
 ### Why?

--- a/build/localnet/Tiltfile
+++ b/build/localnet/Tiltfile
@@ -102,15 +102,24 @@ local_resource(
 docker_build_with_restart(
     "pocket-image",
     root_dir,
-    dockerfile_contents="""FROM debian:bullseye
+    dockerfile_contents="""FROM golang:1.20-bullseye
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 COPY bin/pocket-linux /usr/local/bin/pocket
 WORKDIR /
 """,
     only=["./bin/pocket-linux"],
     entrypoint=[
+        "dlv",
+        "exec",
         "/usr/local/bin/pocket",
-        "-config=/pocket/configs/config.json",
-        "-genesis=/pocket/configs/genesis.json",
+        "--headless",
+        "--listen=:7081",
+        "--api-version=2",
+        "--accept-multiclient",
+        "--continue",
+        "--",
+        "--config=/pocket/configs/config.json",
+        "--genesis=/pocket/configs/genesis.json",
     ],
     live_update=[sync("bin/pocket-linux", "/usr/local/bin/pocket")],
 )


### PR DESCRIPTION
## Description

Add debugging capabilites to k8s LocalNet using dlv server and port forwarding.

reviewpad:summary

## Issue

Fixes #183 

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [x] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Change `TiltFile` to build pocket containers with dlv and start a debugging server to `pocket` binary
- Documentation on how to setup port-forwarding and IDE debugging client


## Testing

- [ ] `make develop_test`; if any code changes were made
- [ ] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [ ] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
