### PR TITLE
[Utility] servicer signs relays

### DIFF
--- a/runtime/configs/proto/servicer_config.proto
+++ b/runtime/configs/proto/servicer_config.proto
@@ -10,16 +10,15 @@ option go_package = "github.com/pokt-network/pocket/runtime/configs";
 message ServicerConfig {
   // Enabled defines whether or not the node is a servicer.
   bool enabled = 1;
-  string public_key = 2;
-  string address = 3;
-  map<string, ServiceConfig> services = 4;
+  string private_key = 2;
+  map<string, ServiceConfig> services = 3;
 
   // relay_mining_volume_accuracy is a parameter used to adjust the calculated number of service tokens for an application.
   // It is introduced to minimize the chance of under-utilization of application's tokens, while removing the overhead of
   // communication between servicers which would be necessary otherwise.
   // See the following for more details:
   //	https://arxiv.org/abs/2305.10672
-  double relay_mining_volume_accuracy = 5;
+  double relay_mining_volume_accuracy = 4;
 }
 
 // ServiceConfig holds configurations related to where/how the application/client can access the backing RPC service. It is analogous to "ChainConfig" in v0 but can support any RPC service.

--- a/utility/module_enable_actors_test.go
+++ b/utility/module_enable_actors_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pokt-network/pocket/runtime"
 	"github.com/pokt-network/pocket/runtime/configs"
+	"github.com/pokt-network/pocket/shared/crypto"
 	"github.com/pokt-network/pocket/shared/modules"
 	mocks "github.com/pokt-network/pocket/shared/modules/mocks"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,9 @@ import (
 )
 
 func TestEnableActorModules(t *testing.T) {
+	privateKey, err := crypto.GeneratePrivateKey()
+	require.NoError(t, err)
+
 	tests := []struct {
 		name                 string
 		config               *configs.Config
@@ -24,7 +28,10 @@ func TestEnableActorModules(t *testing.T) {
 		{
 			name: "servicer only",
 			config: &configs.Config{
-				Servicer: &configs.ServicerConfig{Enabled: true},
+				Servicer: &configs.ServicerConfig{
+					Enabled:    true,
+					PrivateKey: privateKey.String(),
+				},
 			},
 			expectedNames: []string{"servicer"},
 		},
@@ -46,7 +53,10 @@ func TestEnableActorModules(t *testing.T) {
 			name: "validator and servicer",
 			config: &configs.Config{
 				Validator: &configs.ValidatorConfig{Enabled: true},
-				Servicer:  &configs.ServicerConfig{Enabled: true},
+				Servicer: &configs.ServicerConfig{
+					Enabled:    true,
+					PrivateKey: privateKey.String(),
+				},
 			},
 			expectedNames: []string{"validator", "servicer"},
 		},

--- a/utility/servicer/module_test.go
+++ b/utility/servicer/module_test.go
@@ -148,7 +148,7 @@ func TestRelay_Admit(t *testing.T) {
 				sessionHeight(testSessionStartingHeight),
 				sessionServicers(testServicer1),
 			)
-			mockBus := mockBus(t, &config, uint64(testCurrentHeight), session, testCase.usedSessionTokens)
+			mockBus := mockBus(t, config, uint64(testCurrentHeight), session, testCase.usedSessionTokens)
 
 			servicerMod, err := CreateServicer(mockBus)
 			require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestRelay_Execute(t *testing.T) {
 				config.Services[svc].Url = ts.URL
 			}
 
-			servicer := &servicer{config: &config}
+			servicer := &servicer{config: config}
 			_, err := servicer.executeRelay(testCase.relay)
 			require.ErrorIs(t, err, testCase.expectedErr)
 			// INCOMPLETE(@adshmh): verify HTTP request properties: payload/headers/user-agent/etc.
@@ -223,7 +223,7 @@ func TestRelay_Sign(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			config := testServicerConfig(withPrivateKey(testCase.privateKey))
-			mockBus := mockBus(t, &config, 0, &coreTypes.Session{}, 0)
+			mockBus := mockBus(t, config, 0, &coreTypes.Session{}, 0)
 
 			servicerMod, err := CreateServicer(mockBus)
 			if testCase.expectErr {
@@ -315,7 +315,7 @@ func withPrivateKey(key string) func(*configs.ServicerConfig) {
 	}
 }
 
-func testServicerConfig(editors ...configModifier) configs.ServicerConfig {
+func testServicerConfig(editors ...configModifier) *configs.ServicerConfig {
 	config := configs.ServicerConfig{
 		PrivateKey: testServicer1PrivateKey.String(),
 		Services: map[string]*configs.ServiceConfig{
@@ -328,7 +328,7 @@ func testServicerConfig(editors ...configModifier) configs.ServicerConfig {
 		editor(&config)
 	}
 
-	return config
+	return &config
 }
 
 type sessionModifier func(*coreTypes.Session)


### PR DESCRIPTION
## Description

This PR modifies servicer code to sign all the served relays. It also modified the servicer configuration to a) provide the required private key, and b) remove public key and address fields which are now driven from the private key.

## Issue

Fixes #832 

## Type of change

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Updaed servicer config proto file.
- Updated servicer module
- Updated unit tests covering servicer module

## Testing

- [x] `make develop_test`; if any code changes were made
- [ ] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
