### PR TITLE
[Utility] Support RESTful relays (need to merge #960 first)

### DIFF
--- a/app/client/cli/servicer_test.go
+++ b/app/client/cli/servicer_test.go
@@ -71,6 +71,49 @@ func TestGetSessionFromCache(t *testing.T) {
 	}
 }
 
+func TestUnmarshalRelay(t *testing.T) {
+	restPayload := rpc.RESTPayload(`{"field1":"value1"}`)
+
+	testCases := []struct {
+		name      string
+		payload   string
+		expected  *rpc.RelayRequest
+		expectErr bool
+	}{
+		{
+			name:    "JSONRPC payload",
+			payload: `{"jsonrpc": "2.0", "id": "1", "method": "eth_blockNumber"}`,
+			expected: &rpc.RelayRequest{
+				Payload: &rpc.JSONRPCPayload{
+					Jsonrpc: "2.0",
+					Method:  "eth_blockNumber",
+					Id:      &rpc.JsonRpcId{Id: []byte("1")},
+				},
+			},
+		},
+		{
+			name:    "REST payload",
+			payload: `{"field1":"value1"}`,
+			expected: &rpc.RelayRequest{
+				Payload: &restPayload,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// got, err := buildRelay(tc.payload, appPrivateKey, &rpc.Session{}, &rpc.ProtocolActor{})
+			got, err := unmarshalRelayPayload(tc.payload)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.EqualValues(t, *tc.expected, *got)
+		})
+	}
+}
+
 func testSession(appAddr string, height int64) *rpc.Session {
 	const numSessionBlocks = 4
 

--- a/app/client/cli/servicer_test.go
+++ b/app/client/cli/servicer_test.go
@@ -98,11 +98,15 @@ func TestUnmarshalRelay(t *testing.T) {
 				Payload: &restPayload,
 			},
 		},
+		{
+			name:      "Payload with invalid format is rejected",
+			payload:   "foo",
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// got, err := buildRelay(tc.payload, appPrivateKey, &rpc.Session{}, &rpc.ProtocolActor{})
 			got, err := unmarshalRelayPayload(tc.payload)
 			if tc.expectErr {
 				require.Error(t, err)

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/pokt-network/pocket/app"
 	coreTypes "github.com/pokt-network/pocket/shared/core/types"
 )
+
+var errInvalidJsonRpc = errors.New("JSONRPC validation failed")
 
 // CONSIDER: Remove all the V1 prefixes from the RPC module
 

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -2,6 +2,8 @@ package rpc
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -83,9 +85,7 @@ func (s *rpcServer) PostV1ClientGetSession(ctx echo.Context) error {
 }
 
 func (s *rpcServer) PostV1ClientRelay(ctx echo.Context) error {
-	utility := s.GetBus().GetUtilityModule()
-	_, err := utility.GetServicerModule()
-
+	servicer, err := s.GetBus().GetUtilityModule().GetServicerModule()
 	if err != nil {
 		return ctx.String(http.StatusInternalServerError, "node is not a servicer")
 	}
@@ -123,7 +123,7 @@ func (s *rpcServer) PostV1ClientRelay(ctx echo.Context) error {
 	}
 	relayRequest.Meta = relayMeta
 
-	relayResponse, err := utility.HandleRelay(relayRequest)
+	relayResponse, err := servicer.HandleRelay(relayRequest)
 	if err != nil {
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}
@@ -263,4 +263,69 @@ func buildRestRelayPayload(src *RESTPayload) *coreTypes.Relay {
 			},
 		},
 	}
+}
+
+// UnmarshalJSON is the custom unmarshaller for RelayRequest type. This is needed because the payload could be JSONRPC or REST.
+func (r *RelayRequest) UnmarshalJSON(data []byte) error {
+	type relayWithJsonRpcPayload struct {
+		Meta    RelayRequestMeta `json:"meta"`
+		Payload JSONRPCPayload   `json:"payload"`
+	}
+	var jsonRpcRelay relayWithJsonRpcPayload
+	if err := json.Unmarshal(data, &jsonRpcRelay); err == nil && jsonRpcRelay.Payload.Validate() == nil {
+		r.Meta = jsonRpcRelay.Meta
+		r.Payload = jsonRpcRelay.Payload
+		return nil
+	} 
+
+	type relayWithRestPayload struct {
+		Meta    RelayRequestMeta `json:"meta"`
+		Payload RESTPayload `json:"payload"`
+	}
+	var restRelay relayWithRestPayload
+	if err := json.Unmarshal(data, &restRelay); err == nil {
+		r.Meta = restRelay.Meta
+		r.Payload = restRelay.Payload
+		return nil
+	} 
+
+	return fmt.Errorf("invalid relay: %s", string(data))
+}
+
+// Validate returns an error if the payload struct is not valid JSONRPC
+func (p *JSONRPCPayload) Validate() error {
+	if p.Method == "" {
+		return fmt.Errorf("%w: missing method field", errInvalidJsonRpc)
+	}
+
+	if p.Jsonrpc != "2.0" {
+		return fmt.Errorf("%w: invalid JSONRPC field value: %q", errInvalidJsonRpc, p.Jsonrpc)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON is the custom unmarshaller for JsonRpcId type. It is needed because JSONRPC spec allows the "id" field to be nil, an integer, or a string.
+//
+//	See the following link for more details:
+//	https://www.jsonrpc.org/specification#request_object
+func (i *JsonRpcId) UnmarshalJSON(data []byte) error {
+	var v int64
+	if err := json.Unmarshal(data, &v); err == nil {
+		i.Id = []byte(fmt.Sprintf("%d", v))
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		i.Id = []byte(s)
+		return nil
+	}
+
+	return fmt.Errorf("invalid JSONRPC ID value: %v", data)
+}
+
+// MarshalJSON is the custom marshaller for JsonRpcId type. It is needed to flatten the struct as a single value, i.e. mask the "Id" field.
+func (i *JsonRpcId) MarshalJSON() ([]byte, error) {
+	return i.Id, nil
 }

--- a/rpc/handlers.go
+++ b/rpc/handlers.go
@@ -276,18 +276,18 @@ func (r *RelayRequest) UnmarshalJSON(data []byte) error {
 		r.Meta = jsonRpcRelay.Meta
 		r.Payload = jsonRpcRelay.Payload
 		return nil
-	} 
+	}
 
 	type relayWithRestPayload struct {
 		Meta    RelayRequestMeta `json:"meta"`
-		Payload RESTPayload `json:"payload"`
+		Payload RESTPayload      `json:"payload"`
 	}
 	var restRelay relayWithRestPayload
 	if err := json.Unmarshal(data, &restRelay); err == nil {
 		r.Meta = restRelay.Meta
 		r.Payload = restRelay.Payload
 		return nil
-	} 
+	}
 
 	return fmt.Errorf("invalid relay: %s", string(data))
 }

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -19,19 +19,19 @@ import (
 type testRelayHandler func(relay *coreTypes.Relay) (*coreTypes.RelayResponse, error)
 
 func TestRPCServer_PostV1Client(t *testing.T) {
-	testCases := []struct{
-		name string
-		relay RelayRequest
-		handler testRelayHandler
+	testCases := []struct {
+		name             string
+		relay            RelayRequest
+		handler          testRelayHandler
 		expectedResponse string
 	}{
 		{
 			name: "JSONRPC payload is processed correctly",
 			relay: RelayRequest{
-				Payload: JSONRPCPayload {
+				Payload: JSONRPCPayload{
 					Jsonrpc: "2.0",
-					Method: "eth_blockNumber",
-					Id: &JsonRpcId{Id: []byte("1")},
+					Method:  "eth_blockNumber",
+					Id:      &JsonRpcId{Id: []byte("1")},
 				},
 			},
 			handler: func(relay *coreTypes.Relay) (*coreTypes.RelayResponse, error) {
@@ -60,7 +60,7 @@ func TestRPCServer_PostV1Client(t *testing.T) {
 			relay: RelayRequest{
 				Payload: "foo",
 			},
-			handler: func(_ *coreTypes.Relay) (*coreTypes.RelayResponse, error) { return nil, nil },
+			handler:          func(_ *coreTypes.Relay) (*coreTypes.RelayResponse, error) { return nil, nil },
 			expectedResponse: "bad request",
 		},
 	}

--- a/rpc/handlers_test.go
+++ b/rpc/handlers_test.go
@@ -1,0 +1,114 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	coreTypes "github.com/pokt-network/pocket/shared/core/types"
+	mockModules "github.com/pokt-network/pocket/shared/modules/mocks"
+)
+
+type testRelayHandler func(relay *coreTypes.Relay) (*coreTypes.RelayResponse, error)
+
+func TestRPCServer_PostV1Client(t *testing.T) {
+	testCases := []struct{
+		name string
+		relay RelayRequest
+		handler testRelayHandler
+		expectedResponse string
+	}{
+		{
+			name: "JSONRPC payload is processed correctly",
+			relay: RelayRequest{
+				Payload: JSONRPCPayload {
+					Jsonrpc: "2.0",
+					Method: "eth_blockNumber",
+					Id: &JsonRpcId{Id: []byte("1")},
+				},
+			},
+			handler: func(relay *coreTypes.Relay) (*coreTypes.RelayResponse, error) {
+				payload := relay.GetJsonRpcPayload()
+				require.EqualValues(t, payload.Id, []byte("1"))
+				require.Equal(t, payload.JsonRpc, "2.0")
+				require.Equal(t, payload.Method, "eth_blockNumber")
+				return &coreTypes.RelayResponse{Payload: "JSONRPC Relay Response"}, nil
+			},
+			expectedResponse: `{"payload":"JSONRPC Relay Response","servicer_signature":""}`,
+		},
+		{
+			name: "REST payload is processed correctly",
+			relay: RelayRequest{
+				Payload: RESTPayload(`{"field1":"value1"}`),
+			},
+			handler: func(relay *coreTypes.Relay) (*coreTypes.RelayResponse, error) {
+				payload := relay.GetRestPayload()
+				require.Equal(t, &coreTypes.RESTPayload{Contents: []byte(`{"field1":"value1"}`)}, payload)
+				return &coreTypes.RelayResponse{Payload: "REST Relay Response"}, nil
+			},
+			expectedResponse: `{"payload":"REST Relay Response","servicer_signature":""}`,
+		},
+		{
+			name: "Invalid payload is rejected",
+			relay: RelayRequest{
+				Payload: "foo",
+			},
+			handler: func(_ *coreTypes.Relay) (*coreTypes.RelayResponse, error) { return nil, nil },
+			expectedResponse: "bad request",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			bz, err := json.Marshal(testCase.relay)
+			require.NoError(t, err)
+			req := httptest.NewRequest("POST", "/v1/relay", bytes.NewReader(bz))
+			req.Header.Add("Content-Type", "application/json")
+
+			responseRecorder := httptest.NewRecorder()
+			ctx := echo.New().NewContext(req, responseRecorder)
+
+			mockBus := mockBus(t, testCase.handler)
+			rpcServer := NewRPCServer(mockBus)
+
+			err = rpcServer.PostV1ClientRelay(ctx)
+			require.NoError(t, err)
+
+			resp := responseRecorder.Result()
+			defer resp.Body.Close()
+			responseBody, err := io.ReadAll(resp.Body)
+
+			require.EqualValues(t, testCase.expectedResponse, strings.TrimRight(string(responseBody), "\n"))
+		})
+	}
+}
+
+// Create a mockBus with mock implementations of the utility module
+func mockBus(t *testing.T, handler testRelayHandler) *mockModules.MockBus {
+	ctrl := gomock.NewController(t)
+	busMock := mockModules.NewMockBus(ctrl)
+	busMock.EXPECT().GetUtilityModule().Return(baseUtilityMock(ctrl, handler)).AnyTimes()
+	return busMock
+}
+
+// Creates utility and servicer modules mocks with mock implementations of some basic functionality
+func baseUtilityMock(ctrl *gomock.Controller, handler testRelayHandler) *mockModules.MockUtilityModule {
+	servicerMock := mockModules.NewMockServicerModule(ctrl)
+	servicerMock.EXPECT().
+		HandleRelay(gomock.Any()).
+		DoAndReturn(
+			func(relay *coreTypes.Relay) (*coreTypes.RelayResponse, error) {
+				return handler(relay)
+			}).AnyTimes()
+
+	utilityMock := mockModules.NewMockUtilityModule(ctrl)
+	utilityMock.EXPECT().GetServicerModule().Return(servicerMock, nil).AnyTimes()
+	return utilityMock
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -1,9 +1,7 @@
 package rpc
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -71,37 +69,4 @@ func (s *rpcServer) StartRPC(port string, timeout uint64, logger *modules.Logger
 	if err := e.Start(":" + port); err != http.ErrServerClosed {
 		s.logger.Fatal().Err(err).Msg("RPC server failed to start")
 	}
-}
-
-// Validate returns an error if the payload struct is not valid JSONRPC
-func (p *JSONRPCPayload) Validate() error {
-	if p.Method == "" {
-		return fmt.Errorf("%w: missing method field", errInvalidJsonRpc)
-	}
-
-	if p.Jsonrpc != "2.0" {
-		return fmt.Errorf("%w: invalid JSONRPC field value: %q", errInvalidJsonRpc, p.Jsonrpc)
-	}
-
-	return nil
-}
-
-// UnmarshalJSON is the custom unmarshaller for JsonRpcId type. It is needed because JSONRPC spec allows the "id" field to be nil, an integer, or a string.
-//
-//	See the following link for more details:
-//	https://www.jsonrpc.org/specification#request_object
-func (i *JsonRpcId) UnmarshalJSON(data []byte) error {
-	var v int64
-	if err := json.Unmarshal(data, &v); err == nil {
-		i.Id = []byte(fmt.Sprintf("%d", v))
-		return nil
-	}
-
-	var s string
-	if err := json.Unmarshal(data, &s); err == nil {
-		i.Id = []byte(s)
-		return nil
-	}
-
-	return fmt.Errorf("invalid JSONRPC ID value: %v", data)
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
@@ -20,8 +19,6 @@ type rpcServer struct {
 var (
 	_ ServerInterface          = &rpcServer{}
 	_ modules.IntegrableModule = &rpcServer{}
-
-	errInvalidJsonRpc = errors.New("JSONRPC validation failed")
 )
 
 func NewRPCServer(bus modules.Bus) *rpcServer {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -1,6 +1,9 @@
 package rpc
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -19,6 +22,8 @@ type rpcServer struct {
 var (
 	_ ServerInterface          = &rpcServer{}
 	_ modules.IntegrableModule = &rpcServer{}
+
+	errInvalidJsonRpc = errors.New("JSONRPC validation failed")
 )
 
 func NewRPCServer(bus modules.Bus) *rpcServer {
@@ -66,4 +71,37 @@ func (s *rpcServer) StartRPC(port string, timeout uint64, logger *modules.Logger
 	if err := e.Start(":" + port); err != http.ErrServerClosed {
 		s.logger.Fatal().Err(err).Msg("RPC server failed to start")
 	}
+}
+
+// Validate returns an error if the payload struct is not valid JSONRPC
+func (p *JSONRPCPayload) Validate() error {
+	if p.Method == "" {
+		return fmt.Errorf("%w: missing method field", errInvalidJsonRpc)
+	}
+
+	if p.Jsonrpc != "2.0" {
+		return fmt.Errorf("%w: invalid JSONRPC field value: %q", errInvalidJsonRpc, p.Jsonrpc)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON is the custom unmarshaller for JsonRpcId type. It is needed because JSONRPC spec allows the "id" field to be nil, an integer, or a string.
+//
+//	See the following link for more details:
+//	https://www.jsonrpc.org/specification#request_object
+func (i *JsonRpcId) UnmarshalJSON(data []byte) error {
+	var v int64
+	if err := json.Unmarshal(data, &v); err == nil {
+		i.Id = []byte(fmt.Sprintf("%d", v))
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		i.Id = []byte(s)
+		return nil
+	}
+
+	return fmt.Errorf("invalid JSONRPC ID value: %v", data)
 }

--- a/rpc/v1/openapi.yaml
+++ b/rpc/v1/openapi.yaml
@@ -1082,7 +1082,9 @@ components:
         - meta
       properties:
         payload:
-          $ref: "#/components/schemas/Payload"
+          oneOf:
+            - $ref: "#/components/schemas/JSONRPCPayload"
+            - $ref: "#/components/schemas/RESTPayload"
         meta:
           $ref: "#/components/schemas/RelayRequestMeta"
     SessionRequest:
@@ -1704,15 +1706,14 @@ components:
           type: string
         address:
           type: string
-    Payload:
+    JSONRPCPayload:
       type: object
       required:
         - jsonrpc
         - method
       properties:
         id:
-          type: string
-          format: byte
+          $ref: "#/components/schemas/JsonRpcId"
         jsonrpc:
           type: string
         method:
@@ -1722,6 +1723,16 @@ components:
           format: byte
         headers:
           $ref: "#/components/schemas/Headers"
+    JsonRpcId:
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          format: byte
+    RESTPayload:
+      type: string
+      format: byte
     Pool:
       type: object
       required:

--- a/shared/core/types/proto/relay.proto
+++ b/shared/core/types/proto/relay.proto
@@ -19,7 +19,7 @@ message Relay {
 
 // INCOMPLETE: add REST relay payload fields
 message RESTPayload {
-    string contents = 1;
+    bytes contents = 1;
     string http_path = 2;
     RESTRequestType request_type = 3;
 }

--- a/shared/core/types/relay.go
+++ b/shared/core/types/relay.go
@@ -14,6 +14,7 @@ var (
 	errInvalidJSONRPC              = errors.New("invalid value for JSONRPC field")
 	errInvalidJSONRPCMissingMethod = errors.New("Method field not set")
 	errInvalidRESTPayload          = errors.New("invalid REST payload")
+	errInvalidRESTMethod           = errors.New("invalid REST method")
 )
 
 // IMPROVE: use a factory function to build test relays
@@ -48,6 +49,16 @@ func (p *JSONRPCPayload) Validate() error {
 
 // Validate verifies that the payload is valid REST, i.e. valid JSON
 func (p *RESTPayload) Validate() error {
+	validMethods := map[RESTRequestType]struct{}{
+		RESTRequestType_RESTRequestTypeGET:    {},
+		RESTRequestType_RESTRequestTypePUT:    {},
+		RESTRequestType_RESTRequestTypePOST:   {},
+		RESTRequestType_RESTRequestTypeDELETE: {},
+	}
+	if _, ok := validMethods[p.RequestType]; !ok {
+		return fmt.Errorf("%w: invalid REST method: %d", errInvalidRESTMethod, p.RequestType)
+	}
+
 	var parsed json.RawMessage
 	if err := json.Unmarshal([]byte(p.Contents), &parsed); err != nil {
 		return fmt.Errorf("%w: %s: %s", errInvalidRESTPayload, p.Contents, err.Error())

--- a/shared/core/types/relay_test.go
+++ b/shared/core/types/relay_test.go
@@ -103,8 +103,13 @@ func TestRelay_ValidateREST(t *testing.T) {
 		},
 		{
 			name:     "invalid REST payload: is not JSON-formatted",
-			payload:  &RESTPayload{Contents: "foo"},
+			payload:  &RESTPayload{Contents: "foo", RequestType: RESTRequestType_RESTRequestTypeGET},
 			expected: errInvalidRESTPayload,
+		},
+		{
+			name:     "invalid REST payload: invalid request type",
+			payload:  &RESTPayload{Contents: `{"field1": "value1"}`, RequestType: RESTRequestType(99999)},
+			expected: errInvalidRESTMethod,
 		},
 	}
 

--- a/shared/modules/servicer_module.go
+++ b/shared/modules/servicer_module.go
@@ -1,0 +1,16 @@
+package modules
+
+//go:generate mockgen -destination=./mocks/servicer_module_mock.go github.com/pokt-network/pocket/shared/modules ServicerModule
+
+import (
+	coreTypes "github.com/pokt-network/pocket/shared/core/types"
+)
+
+const (
+	ServicerModuleName = "servicer"
+)
+
+type ServicerModule interface {
+	Module
+	HandleRelay(*coreTypes.Relay) (*coreTypes.RelayResponse, error)
+}

--- a/shared/modules/utility_module.go
+++ b/shared/modules/utility_module.go
@@ -62,11 +62,6 @@ type FishermanModule interface {
 	Module
 }
 
-type ServicerModule interface {
-	Module
-	HandleRelay(*coreTypes.Relay) (*coreTypes.RelayResponse, error)
-}
-
 type ValidatorModule interface {
 	Module
 }

--- a/utility/module.go
+++ b/utility/module.go
@@ -142,10 +142,10 @@ func (u *utilityModule) GetActorModules() map[string]modules.Module {
 }
 
 func (u *utilityModule) GetServicerModule() (modules.ServicerModule, error) {
-	if u.actorModules[servicer.ServicerModuleName] == nil {
+	if u.actorModules[modules.ServicerModuleName] == nil {
 		return nil, errors.New("servicer module not enabled")
 	}
-	if m, ok := u.actorModules[servicer.ServicerModuleName].(modules.ServicerModule); ok {
+	if m, ok := u.actorModules[modules.ServicerModuleName].(modules.ServicerModule); ok {
 		return m, nil
 	}
 	return nil, errors.New("failed to cast servicer module")

--- a/utility/servicer/module.go
+++ b/utility/servicer/module.go
@@ -35,10 +35,6 @@ var (
 	_ modules.ServicerModule = &servicer{}
 )
 
-const (
-	ServicerModuleName = "servicer"
-)
-
 // sessionTokens is used to cache the starting number of tokens available
 // during a specific session: it is used as the value for a map with keys being applications' public keys
 // TODO: What if we have a servicer managing more than one session from the same app at once? We may/may not need to resolve this in the future.
@@ -121,7 +117,7 @@ func (s *servicer) Stop() error {
 }
 
 func (s *servicer) GetModuleName() string {
-	return ServicerModuleName
+	return modules.ServicerModuleName
 }
 
 // HandleRelay processes a relay after performing validation.

--- a/utility/servicer/module_test.go
+++ b/utility/servicer/module_test.go
@@ -181,6 +181,10 @@ func TestRelay_Execute(t *testing.T) {
 			name:  "JSONRPC Relay is executed",
 			relay: testRelay(testEthGoerliRelay()),
 		},
+		{
+			name:  "REST Relay is executed",
+			relay: testRelay(testRESTRelay()),
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -279,6 +283,17 @@ func testEthGoerliRelay() relayEditor {
 	}
 }
 
+func testRESTRelay() relayEditor {
+	return func(relay *coreTypes.Relay) {
+		relay.Meta.RelayChain.Id = "RESTful-service"
+		relay.RelayPayload = &coreTypes.Relay_RestPayload{
+			RestPayload: &coreTypes.RESTPayload{
+				Contents: []byte(`{"field1": "value1"}`),
+			},
+		}
+	}
+}
+
 func testRelay(editors ...relayEditor) *coreTypes.Relay {
 	relay := &coreTypes.Relay{
 		Meta: &coreTypes.RelayMeta{
@@ -321,6 +336,7 @@ func testServicerConfig(editors ...configModifier) *configs.ServicerConfig {
 		Services: map[string]*configs.ServiceConfig{
 			"POKT-UnitTestNet": testServiceConfig1,
 			"ETH-Goerli":       testServiceConfig1,
+			"RESTful-service":  testServiceConfig1,
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR adds support for relays in REST format, i.e. with JSON payload rather than JSONRPC, and optionally specify a Path and the HTTP Method. 

## Issue

Part of work on #860 

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Update RPC structs and handlers to support REST
- Update client binary to handle REST
- Update Servicer logic to handle REST

## Testing

- [x] `make develop_test`; if any code changes were made
- [ ] `make test_e2e` on [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any code changes were made
- [ ] `e2e-devnet-test` passes tests on [DevNet](https://pocketnetwork.notion.site/How-to-DevNet-ff1598f27efe44c09f34e2aa0051f0dd); if any code was changed
- [ ] [Docker Compose LocalNet](https://github.com/pokt-network/pocket/blob/main/docs/development/README.md); if any major functionality was changed or introduced
- [ ] [k8s LocalNet](https://github.com/pokt-network/pocket/blob/main/build/localnet/README.md); if any infrastructure or configuration changes were made

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling
- [ ] I have updated the corresponding CHANGELOG

### If Applicable Checklist

- [ ] I have updated the corresponding README(s); local and/or global
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added, or updated, [mermaid.js](https://mermaid-js.github.io) diagrams in the corresponding README(s)
- [ ] I have added, or updated, documentation and [mermaid.js](https://mermaid-js.github.io) diagrams in `shared/docs/*` if I updated `shared/*`README(s)
