### PR TITLE
[utility] fix failed to create servicer

### DIFF
--- a/build/config/config.validator1.json
+++ b/build/config/config.validator1.json
@@ -56,13 +56,14 @@
   },
   "servicer": {
     "enabled": true,
-    "chains": ["0001"]
+    "chains": ["0001"],
+    "private_key": "0ca1a40ddecdab4f5b04fa0bfed1d235beaa2b8082e7554425607516f0862075dfe357de55649e6d2ce889acf15eb77e94ab3c5756fe46d3c7538d37f27f115e"
   },
   "ibc": {
     "enabled": true,
     "stores_dir": "/var/ibc",
     "host": {
-        "private_key": "0ca1a40ddecdab4f5b04fa0bfed1d235beaa2b8082e7554425607516f0862075dfe357de55649e6d2ce889acf15eb77e94ab3c5756fe46d3c7538d37f27f115e"
+      "private_key": "0ca1a40ddecdab4f5b04fa0bfed1d235beaa2b8082e7554425607516f0862075dfe357de55649e6d2ce889acf15eb77e94ab3c5756fe46d3c7538d37f27f115e"
     }
   }
 }


### PR DESCRIPTION
Adds servicer pk to validator1 docker compose deployment

Fixes `failed to create servicer` in the utility module for validator1 deployment.

There are probably more places this needs to be fixed, but this unblocked me after rebasing off main.